### PR TITLE
feat: scaffold pnpm monorepo workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# Sentinel — CLAUDE.md
+
+## Project Overview
+
+Sentinel is an open-source, AI-first autonomous QA automation platform structured as a pnpm monorepo.
+
+## Annotated Directory Structure
+
+```
+sentinel/
+├── packages/
+│   ├── shared/           # @sentinel/shared — shared types and utilities (no internal deps)
+│   │   └── src/
+│   │       └── index.ts  # Public API: version constants, CheckResult discriminated union
+│   ├── core/             # @sentinel/core — domain models and core business logic
+│   │   └── src/
+│   │       └── index.ts  # Public API: Scenario interface, re-exports from shared
+│   ├── cli/              # @sentinel/cli — command-line interface entry point
+│   │   └── src/
+│   │       └── index.ts  # Public API: CLI_NAME, re-exports from core/shared
+│   └── web/              # @sentinel/web — web application entry point
+│       └── src/
+│           └── index.ts  # Public API: APP_TITLE, re-exports from core/shared
+├── tsconfig.json         # Base config: strict, ES2022, NodeNext, path aliases
+├── tsconfig.build.json   # Composite build references in dependency order
+├── pnpm-workspace.yaml   # Declares packages/* as workspace members
+├── package.json          # Root: scripts (build/clean/typecheck), typescript devDep
+├── README.md             # Setup and usage documentation
+└── CLAUDE.md             # This file
+```
+
+## Key Conventions
+
+- All packages are private and scoped under `@sentinel/`
+- TypeScript strict mode is enforced across all packages
+- Cross-package imports use the `@sentinel/*` path aliases defined in the root `tsconfig.json`
+- Build order is enforced via TypeScript project references in `tsconfig.build.json`
+- Only `typescript` and `@types/node` are permitted as dependencies at this stage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Sentinel
+
+An open-source, AI-first autonomous QA automation platform.
+
+## Prerequisites
+
+- Node.js >= 20
+- pnpm >= 10
+
+## Setup
+
+Install dependencies from the repository root:
+
+```sh
+pnpm install
+```
+
+## Scripts
+
+| Command              | Description                                    |
+| -------------------- | ---------------------------------------------- |
+| `pnpm run build`     | Compile all packages in dependency order       |
+| `pnpm run clean`     | Remove all compiled output                     |
+| `pnpm run typecheck` | Type-check all packages without emitting files |
+
+## Workspace Structure
+
+```
+sentinel/
+├── packages/
+│   ├── shared/   # Shared types and utilities — no internal dependencies
+│   ├── core/     # Core domain logic; depends on @sentinel/shared
+│   ├── cli/      # Command-line interface; depends on @sentinel/core and @sentinel/shared
+│   └── web/      # Web interface; depends on @sentinel/core and @sentinel/shared
+├── tsconfig.json         # Base TypeScript configuration extended by each package
+├── tsconfig.build.json   # Project references for ordered composite builds
+└── pnpm-workspace.yaml   # Workspace package locations
+```
+
+## Package Dependency Graph
+
+```
+@sentinel/shared
+       ↑
+@sentinel/core
+       ↑
+@sentinel/cli   @sentinel/web
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "sentinel",
+  "private": true,
+  "version": "0.0.0",
+  "description": "An open-source, AI-first autonomous QA automation platform",
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "pnpm@10.0.0",
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "clean": "tsc --build --clean tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sentinel/cli",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sentinel/core": "workspace:*",
+    "@sentinel/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @sentinel/cli
+ *
+ * Command-line interface for the Sentinel QA automation platform.
+ */
+
+export type { Scenario, CheckResult } from "@sentinel/core";
+export { SENTINEL_VERSION } from "@sentinel/shared";
+
+/** Entry point descriptor for the Sentinel CLI. */
+export const CLI_NAME = "sentinel" as const;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../shared" },
+    { "path": "../core" }
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@sentinel/core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sentinel/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @sentinel/core
+ *
+ * Core domain logic for the Sentinel QA automation platform.
+ */
+
+export type { CheckResult, SentinelVersion } from "@sentinel/shared";
+export { SENTINEL_VERSION } from "@sentinel/shared";
+
+/** Represents a single automated QA scenario to be executed by Sentinel. */
+export interface Scenario {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../shared" }
+  ]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sentinel/shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @sentinel/shared
+ *
+ * Shared types and utilities used across all Sentinel packages.
+ */
+
+export const SENTINEL_VERSION = "0.0.0" as const;
+
+export type SentinelVersion = typeof SENTINEL_VERSION;
+
+/** Represents the result of a QA check — either a pass or a structured failure. */
+export type CheckResult =
+  | { status: "pass" }
+  | { status: "fail"; reason: string };

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sentinel/web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sentinel/core": "workspace:*",
+    "@sentinel/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @sentinel/web
+ *
+ * Web interface for the Sentinel QA automation platform.
+ */
+
+export type { Scenario, CheckResult } from "@sentinel/core";
+export { SENTINEL_VERSION } from "@sentinel/shared";
+
+/** Application name used in the web UI. */
+export const APP_TITLE = "Sentinel" as const;

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../shared" },
+    { "path": "../core" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,90 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/cli:
+    dependencies:
+      '@sentinel/core':
+        specifier: workspace:*
+        version: link:../core
+      '@sentinel/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/core:
+    dependencies:
+      '@sentinel/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/shared:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/web:
+    dependencies:
+      '@sentinel/core':
+        specifier: workspace:*
+        version: link:../core
+      '@sentinel/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+packages:
+
+  '@types/node@22.19.11':
+    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@types/node@22.19.11':
+    dependencies:
+      undici-types: 6.21.0
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/shared" },
+    { "path": "./packages/core" },
+    { "path": "./packages/cli" },
+    { "path": "./packages/web" }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "paths": {
+      "@sentinel/core": ["./packages/core/src/index.ts"],
+      "@sentinel/cli": ["./packages/cli/src/index.ts"],
+      "@sentinel/web": ["./packages/web/src/index.ts"],
+      "@sentinel/shared": ["./packages/shared/src/index.ts"]
+    }
+  },
+  "exclude": ["node_modules", "**/dist/**"]
+}


### PR DESCRIPTION
## Summary
- Initialize pnpm workspace with `packages/*` configuration
- Create four workspace packages: `@sentinel/core`, `@sentinel/cli`, `@sentinel/web`, `@sentinel/shared`
- Configure TypeScript with strict mode, project references, and path aliases
- Root-level `build`, `typecheck`, and `clean` scripts verified working

## Test plan
- [x] `pnpm install` completes without errors
- [x] `pnpm run build` builds all packages in dependency order
- [x] `pnpm run typecheck` passes with no errors

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)