### PR TITLE
docs: add contribution guidelines and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug Report
+description: Report a bug in Sentinel
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill out the information below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Sentinel Version
+      description: Which version of Sentinel are you using?
+      placeholder: e.g., 0.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      description: Output of `node --version`
+      placeholder: e.g., v20.11.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Please copy and paste any relevant log output.
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/elderfo/sentinel/discussions
+    about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Suggest a new feature for Sentinel
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a feature. Please fill out the information below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: What problem does this feature solve? Is it related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Nice to have
+        - Important
+        - Critical
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or mockups for the feature request.

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -1,0 +1,54 @@
+name: User Story
+description: Describe a feature from the user's perspective
+title: "Story: As a [role], I want [feature] so that [benefit]"
+labels: ["user-story"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to describe a feature in terms of who needs it, what they need, and why.
+
+  - type: input
+    id: role
+    attributes:
+      label: As a...
+      description: Who is the user or persona?
+      placeholder: e.g., QA Engineer, Developer, Platform Admin
+    validations:
+      required: true
+
+  - type: textarea
+    id: want
+    attributes:
+      label: I want...
+      description: What capability or feature do they need?
+      placeholder: Describe the desired functionality
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefit
+    attributes:
+      label: So that...
+      description: What benefit or outcome does this provide?
+      placeholder: Describe the value or reason
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the conditions that must be met for this story to be complete.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, dependencies, or constraints.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Related Issues
+
+<!-- Link related issues using "Closes #<number>" or "Relates to #<number>" -->
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD changes
+
+## Testing Steps
+
+<!-- Describe how reviewers can test your changes -->
+
+1.
+2.
+3.
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my own code
+- [ ] I have added tests that prove my fix is effective or my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I have updated the documentation accordingly
+- [ ] My commits follow the Conventional Commits specification

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a welcoming experience for everyone.
+
+We pledge to act and interact in ways that contribute to an open, inclusive,
+healthy, and productive community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, and personal attacks
+- Public or private communication that others would reasonably find unwelcoming
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers at
+**sentinel-conduct@elderfo.com**.
+
+All reports will be reviewed and investigated promptly and fairly. All community
+leaders are obligated to respect the privacy and security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,254 @@
+# Contributing to Sentinel
+
+Thank you for your interest in contributing to Sentinel, an open-source, AI-first autonomous QA automation platform! We appreciate your time and effort to help improve the project.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20.0 or higher
+- pnpm 10.0.0 or higher
+
+### Setting Up Your Development Environment
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/elderfo/sentinel.git
+   cd sentinel
+   ```
+
+2. **Install dependencies:**
+
+   ```bash
+   pnpm install
+   ```
+
+3. **Verify your setup:**
+
+   ```bash
+   pnpm typecheck
+   ```
+
+## Branching Strategy
+
+We follow a feature-branch workflow based on the `main` branch:
+
+- **Main branch**: Always deployable, represents the latest stable release
+- **Feature branches**: Created from `main` for new features, bug fixes, or documentation updates
+
+### Branch Naming Conventions
+
+Use conventional branch names that describe the type and scope of work:
+
+- `feat/<feature-name>` - New features
+- `fix/<bug-name>` - Bug fixes
+- `docs/<doc-name>` - Documentation changes
+- `chore/<task-name>` - Maintenance, dependencies, configuration
+- `refactor/<component-name>` - Code refactoring without functionality changes
+- `test/<test-name>` - Test-related changes
+- `ci/<change-name>` - CI/CD pipeline changes
+
+Example: `feat/async-test-execution` or `fix/race-condition-in-scheduler`
+
+## Commit Message Format
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. This format provides clear semantic meaning and enables automated changelog generation.
+
+### Commit Message Structure
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation-only changes
+- **chore**: Changes to build tools, dependencies, or project setup
+- **refactor**: Code changes that neither fix bugs nor add features
+- **test**: Adding or updating tests
+- **ci**: Changes to CI/CD configuration or scripts
+
+### Examples
+
+```
+feat(api): add websocket support for real-time test results
+
+Implement WebSocket server for streaming test execution updates
+to clients. Includes reconnection logic and message queuing.
+
+Closes #42
+```
+
+```
+fix(scheduler): prevent duplicate test executions on retry
+
+The scheduler was not properly tracking completed tasks,
+causing duplicate executions when retrying failed tests.
+```
+
+```
+docs: add troubleshooting guide
+
+Add new troubleshooting section to help users diagnose
+common configuration issues.
+```
+
+### Commit Best Practices
+
+- Write commits in imperative mood ("add feature" not "added feature")
+- Keep commit messages concise and descriptive
+- Sign all commits with your GPG key using the `-S` flag
+- Make atomic commits that represent a single logical change
+- Reference related issues in the commit footer using `Closes #<number>` or `Relates to #<number>`
+
+## Pull Request Process
+
+### Creating a Pull Request
+
+1. **Create your feature branch:**
+
+   ```bash
+   git checkout -b feat/your-feature-name
+   ```
+
+2. **Make your changes:**
+
+   - Implement your feature or fix
+   - Write or update tests as needed
+   - Update documentation
+   - Ensure code style is consistent
+
+3. **Run checks before pushing:**
+
+   ```bash
+   pnpm typecheck
+   pnpm test
+   pnpm lint
+   ```
+
+4. **Commit your changes:**
+
+   ```bash
+   git commit -S -m "feat: your feature description"
+   ```
+
+5. **Push to your fork:**
+
+   ```bash
+   git push origin feat/your-feature-name
+   ```
+
+6. **Open a Pull Request:**
+
+   - Use the provided PR template
+   - Link related issues using `Closes #<number>`
+   - Provide clear description of changes
+   - List testing steps
+   - Mark as draft if work in progress
+
+### PR Review Requirements
+
+- All CI checks must pass
+- Code review approval from at least one maintainer
+- Tests must be added for new functionality
+- Documentation must be updated to reflect changes
+- Code must follow the project's style guidelines
+
+## Code Style
+
+### TypeScript
+
+- **Strict Mode**: All TypeScript files must use strict mode (`"strict": true`)
+- **No `any`**: Avoid using `any` type. Use explicit types or generics instead
+- **Explicit Return Types**: Functions must have explicit return type annotations
+- **Naming Convention**: Use camelCase for variables/functions, PascalCase for classes/interfaces
+
+### Formatting and Linting
+
+Sentinel uses automated tools to enforce code style:
+
+- **ESLint**: Enforces code quality rules
+- **Prettier**: Ensures consistent code formatting
+
+These tools are run automatically via pre-commit hooks (using Husky and lint-staged) before each commit. Violations will prevent commits from being completed.
+
+### Running Checks Manually
+
+```bash
+# Type checking
+pnpm typecheck
+
+# Linting
+pnpm lint
+
+# Formatting (auto-fix)
+pnpm format
+```
+
+## Testing
+
+### Test Requirements
+
+- Unit tests are **required** for all new features
+- Bug fixes should include a test that demonstrates the bug before the fix
+- Aim for meaningful test coverage without pursuing 100% coverage everywhere
+- Keep tests focused and fast; mock external dependencies
+
+### Running Tests
+
+```bash
+# Run all tests
+pnpm test
+
+# Run tests in watch mode
+pnpm test --watch
+
+# Run tests for a specific file
+pnpm test <filename>
+```
+
+### Test Structure
+
+- **Unit tests**: Test individual functions and classes in isolation
+- **Integration tests**: Test component interactions and workflows
+- Keep unit and integration tests clearly separated
+- Use descriptive test names that explain what is being tested
+
+## Documentation
+
+When adding new features or making significant changes:
+
+- Update the relevant documentation files
+- Add or update code examples
+- Document new environment variables
+- Update API documentation if applicable
+- Include migration guides for breaking changes
+
+## Code of Conduct
+
+Please note that this project is released with a [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## Reporting Issues
+
+If you encounter bugs or have feature requests:
+
+1. Check if the issue already exists
+2. Use the appropriate issue template
+3. Provide clear reproduction steps for bugs
+4. Include your environment information
+5. Be respectful and constructive
+
+## Questions or Need Help?
+
+- Check the existing documentation and issues
+- Open a discussion on GitHub
+- Contact the maintainers through GitHub issues
+
+Thank you for contributing to Sentinel!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via email to **sentinel-security@elderfo.com**.
+
+Include the following information in your report:
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Suggested fix (if any)
+
+## Response Timeline
+
+- **Acknowledgment**: Within 48 hours of receiving your report
+- **Initial Assessment**: Within 5 business days
+- **Resolution Target**: Within 30 days for critical issues, 90 days for non-critical
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process:
+
+1. Reporter submits vulnerability privately
+2. We acknowledge receipt and begin investigation
+3. We develop and test a fix
+4. We release the fix and publish a security advisory
+5. Reporter is credited (unless they prefer anonymity)
+
+We ask that you give us reasonable time to address the issue before any public disclosure.
+
+## Scope
+
+This security policy applies to the Sentinel project repository and any official deployments. Third-party integrations and forks are outside the scope of this policy.
+
+Thank you for helping keep Sentinel and its users safe.


### PR DESCRIPTION
## Summary
- Add CONTRIBUTING.md with branching strategy, commit format, and PR process
- Add CODE_OF_CONDUCT.md based on Contributor Covenant v2.1
- Add SECURITY.md with vulnerability reporting process
- Add GitHub issue templates (bug report, feature request, user story)
- Add pull request template

## Test plan
- [ ] Verify issue templates render correctly on GitHub
- [ ] Verify PR template appears when creating new PRs

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)