### PR TITLE
ci: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+# CI Pipeline for Sentinel
+#
+# Branch protection rules should be configured in GitHub repository settings to require:
+#   - This CI workflow ("CI") to pass before merging
+#   - At least one pull request review approval before merging
+#
+# Settings path: Settings > Branches > Add branch protection rule for "main"
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test --coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            packages/*/dist
+            packages/*/tsconfig.tsbuildinfo
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Sentinel is an open-source, AI-first autonomous QA automation platform structure
 
 ```
 sentinel/
+├── .github/
+│   ├── workflows/
+│   │   └── ci.yml        # CI pipeline: lint, typecheck, test, build (fan-in to build)
+│   └── ISSUE_TEMPLATE/   # GitHub issue templates
 ├── packages/
 │   ├── shared/           # @sentinel/shared — shared types and utilities (no internal deps)
 │   │   └── src/


### PR DESCRIPTION
## Summary
- GitHub Actions CI workflow at `.github/workflows/ci.yml`
- Four jobs in fan-in topology: lint, typecheck, test (parallel) → build (gated)
- pnpm store caching via actions/setup-node
- Coverage report uploaded as artifact
- Triggers on PRs to main and pushes to main

## Test plan
- [ ] Workflow triggers on next PR to main
- [ ] All four jobs execute in correct order
- [ ] Coverage artifact is uploaded

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)