### PR TITLE
feat(auth): add Auth0 integration types and JWT verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,26 @@ sentinel/
 ├── packages/
 │   ├── shared/           # @sentinel/shared — shared types and utilities (no internal deps)
 │   │   └── src/
-│   │       ├── index.ts          # Public API: version constants, CheckResult discriminated union
+│   │       ├── index.ts          # Public API: version constants, CheckResult, auth types/config/errors
+│   │       ├── auth/
+│   │       │   ├── types.ts      # AuthConfig, AuthUser, TokenPayload, AuthResult, AuthError interfaces
+│   │       │   ├── config.ts     # loadAuthConfig() — reads Auth0 env vars, throws on missing
+│   │       │   ├── errors.ts     # unauthorizedError, forbiddenError, authConfigError factories
+│   │       │   └── index.ts      # Barrel re-export for auth/
 │   │       └── __tests__/
-│   │           └── index.test.ts # Unit tests for shared exports
+│   │           ├── index.test.ts # Unit tests for shared exports
+│   │           └── auth.test.ts  # Unit tests for auth config loading and error factories
 │   ├── core/             # @sentinel/core — domain models and core business logic
 │   │   └── src/
-│   │       ├── index.ts          # Public API: Scenario interface, re-exports from shared
+│   │       ├── index.ts          # Public API: Scenario interface, auth modules, re-exports from shared
+│   │       ├── auth/
+│   │       │   ├── jwt.ts        # verifyAccessToken(), createAuth0JwksGetter(), JwksGetter type
+│   │       │   ├── middleware.ts  # createAuthMiddleware(), requirePermissions() — framework-agnostic
+│   │       │   ├── user.ts       # tokenPayloadToUser() — maps TokenPayload to AuthUser
+│   │       │   └── index.ts      # Barrel re-export for auth/
 │   │       └── __tests__/
-│   │           └── index.test.ts # Unit tests for core exports
+│   │           ├── index.test.ts # Unit tests for core exports
+│   │           └── auth.test.ts  # Unit tests for JWT verification and auth middleware
 │   ├── cli/              # @sentinel/cli — command-line interface entry point
 │   │   └── src/
 │   │       ├── index.ts          # Public API: CLI_NAME, re-exports from core/shared

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,7 @@ export default [
     languageOptions: {
       parser: tsparser,
       parserOptions: {
-        project: true,
+        projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@sentinel/shared": "workspace:*"
+    "@sentinel/shared": "workspace:*",
+    "jose": "^6.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/core/src/__tests__/auth.test.ts
+++ b/packages/core/src/__tests__/auth.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { SignJWT, generateKeyPair, exportJWK, createLocalJWKSet } from 'jose';
+import type { CryptoKey, JWK } from 'jose';
+import type { AuthConfig } from '@sentinel/shared';
+import { verifyAccessToken } from '../auth/jwt.js';
+import { createAuthMiddleware, requirePermissions } from '../auth/middleware.js';
+import type { JwksGetter } from '../auth/jwt.js';
+import type { AuthRequest } from '../auth/middleware.js';
+
+// ---------------------------------------------------------------------------
+// Shared test fixture — one key pair used across all JWT tests in this file
+// ---------------------------------------------------------------------------
+
+let privateKey: CryptoKey;
+let mockJwks: JwksGetter;
+
+const TEST_CONFIG: AuthConfig = {
+  domain: 'test.auth0.com',
+  clientId: 'client-123',
+  clientSecret: 'secret-abc',
+  audience: 'https://api.test.com',
+  callbackUrl: 'https://app.test.com/callback',
+  logoutUrl: 'https://app.test.com/logout',
+};
+
+const ISSUER = `https://${TEST_CONFIG.domain}/`;
+
+beforeAll(async () => {
+  const { privateKey: priv, publicKey: pub } = await generateKeyPair('RS256');
+  privateKey = priv;
+
+  const publicJwk: JWK = { ...(await exportJWK(pub)), use: 'sig', alg: 'RS256', kid: 'test-key-1' };
+  mockJwks = createLocalJWKSet({ keys: [publicJwk] });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: signs a JWT with the test private key
+// ---------------------------------------------------------------------------
+
+interface TokenOptions {
+  sub?: string;
+  email?: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  permissions?: string[];
+}
+
+async function signTestToken(opts: TokenOptions = {}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const builder = new SignJWT({
+    sub: opts.sub ?? 'user|123',
+    email: opts.email ?? 'user@example.com',
+    ...(opts.permissions !== undefined && { permissions: opts.permissions }),
+  })
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
+    .setIssuer(opts.iss ?? ISSUER)
+    .setAudience(opts.aud ?? TEST_CONFIG.audience)
+    .setIssuedAt(now);
+
+  if (opts.exp !== undefined) {
+    builder.setExpirationTime(opts.exp);
+  } else {
+    builder.setExpirationTime(now + 3600);
+  }
+
+  return builder.sign(privateKey);
+}
+
+// ---------------------------------------------------------------------------
+// verifyAccessToken
+// ---------------------------------------------------------------------------
+
+describe('verifyAccessToken', () => {
+  it('returns a TokenPayload for a valid token', async () => {
+    const token = await signTestToken({ sub: 'user|abc', email: 'alice@example.com' });
+    const payload = await verifyAccessToken(token, TEST_CONFIG, mockJwks);
+
+    expect(payload.sub).toBe('user|abc');
+    expect(payload.email).toBe('alice@example.com');
+    expect(payload.iss).toBe(ISSUER);
+    expect(payload.aud).toBe(TEST_CONFIG.audience);
+  });
+
+  it('includes permissions when present in the token', async () => {
+    const token = await signTestToken({ permissions: ['read:reports', 'write:scenarios'] });
+    const payload = await verifyAccessToken(token, TEST_CONFIG, mockJwks);
+
+    expect(payload.permissions).toEqual(['read:reports', 'write:scenarios']);
+  });
+
+  it('rejects an expired token', async () => {
+    const expired = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signTestToken({ exp: expired });
+
+    await expect(verifyAccessToken(token, TEST_CONFIG, mockJwks)).rejects.toThrow();
+  });
+
+  it('rejects a token with the wrong audience', async () => {
+    const token = await signTestToken({ aud: 'https://wrong-audience.com' });
+
+    await expect(verifyAccessToken(token, TEST_CONFIG, mockJwks)).rejects.toThrow();
+  });
+
+  it('rejects a token with the wrong issuer', async () => {
+    const token = await signTestToken({ iss: 'https://attacker.example.com/' });
+
+    await expect(verifyAccessToken(token, TEST_CONFIG, mockJwks)).rejects.toThrow();
+  });
+
+  it('rejects a malformed token string', async () => {
+    await expect(verifyAccessToken('not.a.jwt', TEST_CONFIG, mockJwks)).rejects.toThrow();
+  });
+
+  it('rejects an empty string', async () => {
+    await expect(verifyAccessToken('', TEST_CONFIG, mockJwks)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAuthMiddleware
+// ---------------------------------------------------------------------------
+
+describe('createAuthMiddleware', () => {
+  const middleware = (): ReturnType<typeof createAuthMiddleware> =>
+    createAuthMiddleware(TEST_CONFIG, mockJwks);
+
+  function makeRequest(authorization?: string): AuthRequest {
+    return {
+      headers: authorization !== undefined ? { authorization } : {},
+    };
+  }
+
+  it('returns authenticated result with user when token is valid', async () => {
+    const token = await signTestToken({
+      sub: 'user|456',
+      email: 'bob@example.com',
+      permissions: ['read:data'],
+    });
+    const result = await middleware()(makeRequest(`Bearer ${token}`));
+
+    expect(result.outcome).toBe('authenticated');
+    if (result.outcome === 'authenticated') {
+      expect(result.user.sub).toBe('user|456');
+      expect(result.user.email).toBe('bob@example.com');
+      expect(result.user.permissions).toEqual(['read:data']);
+    }
+  });
+
+  it('returns 401 error when Authorization header is absent', async () => {
+    const result = await middleware()(makeRequest());
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(401);
+      expect(result.error.code).toBe('UNAUTHORIZED');
+    }
+  });
+
+  it('returns 401 error when header does not start with Bearer', async () => {
+    const result = await middleware()(makeRequest('Basic dXNlcjpwYXNz'));
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(401);
+    }
+  });
+
+  it('returns 401 error for an invalid (tampered) token', async () => {
+    const result = await middleware()(makeRequest('Bearer invalid.token.value'));
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(401);
+    }
+  });
+
+  it('returns 401 error for an expired token', async () => {
+    const exp = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signTestToken({ exp });
+    const result = await middleware()(makeRequest(`Bearer ${token}`));
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(401);
+    }
+  });
+
+  it('handles an array Authorization header value by using the first entry', async () => {
+    const token = await signTestToken({ sub: 'user|789' });
+    const request: AuthRequest = {
+      headers: { authorization: [`Bearer ${token}`, 'Bearer other'] },
+    };
+    const result = await createAuthMiddleware(TEST_CONFIG, mockJwks)(request);
+
+    expect(result.outcome).toBe('authenticated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requirePermissions
+// ---------------------------------------------------------------------------
+
+describe('requirePermissions', () => {
+  it('returns authenticated when user has the required permission', async () => {
+    const token = await signTestToken({ permissions: ['read:reports'] });
+    const payload = await verifyAccessToken(token, TEST_CONFIG, mockJwks);
+    const user = {
+      sub: payload.sub,
+      email: payload.email,
+      name: payload.email,
+      roles: [] as string[],
+      permissions: payload.permissions ?? [],
+    };
+
+    const result = requirePermissions('read:reports')(user);
+    expect(result.outcome).toBe('authenticated');
+  });
+
+  it('returns authenticated when user has all of multiple required permissions', async () => {
+    const token = await signTestToken({
+      permissions: ['read:reports', 'write:scenarios', 'admin'],
+    });
+    const payload = await verifyAccessToken(token, TEST_CONFIG, mockJwks);
+    const user = {
+      sub: payload.sub,
+      email: payload.email,
+      name: payload.email,
+      roles: [] as string[],
+      permissions: payload.permissions ?? [],
+    };
+
+    const result = requirePermissions('read:reports', 'write:scenarios')(user);
+    expect(result.outcome).toBe('authenticated');
+  });
+
+  it('returns 403 error when the user is missing a required permission', async () => {
+    const token = await signTestToken({ permissions: ['read:reports'] });
+    const payload = await verifyAccessToken(token, TEST_CONFIG, mockJwks);
+    const user = {
+      sub: payload.sub,
+      email: payload.email,
+      name: payload.email,
+      roles: [] as string[],
+      permissions: payload.permissions ?? [],
+    };
+
+    const result = requirePermissions('write:scenarios')(user);
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(403);
+      expect(result.error.code).toBe('FORBIDDEN');
+      expect(result.error.message).toContain('write:scenarios');
+    }
+  });
+
+  it('returns 403 when user has no permissions at all', () => {
+    const user = {
+      sub: 'user|000',
+      email: 'nobody@example.com',
+      name: 'nobody@example.com',
+      roles: [] as string[],
+      permissions: [] as string[],
+    };
+
+    const result = requirePermissions('admin')(user);
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(403);
+    }
+  });
+});

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,0 +1,10 @@
+export { verifyAccessToken, createAuth0JwksGetter } from './jwt.js';
+export type { JwksGetter } from './jwt.js';
+export { tokenPayloadToUser } from './user.js';
+export { createAuthMiddleware, requirePermissions } from './middleware.js';
+export type {
+  AuthRequest,
+  AuthMiddlewareResult,
+  AuthMiddlewareFn,
+  PermissionMiddlewareFn,
+} from './middleware.js';

--- a/packages/core/src/auth/jwt.ts
+++ b/packages/core/src/auth/jwt.ts
@@ -1,0 +1,80 @@
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import type { JWSHeaderParameters, FlattenedJWSInput, CryptoKey } from 'jose';
+import type { AuthConfig, TokenPayload } from '@sentinel/shared';
+
+/**
+ * The minimal callable shape that jose's jwtVerify accepts as a key resolver.
+ * Both createLocalJWKSet and createRemoteJWKSet satisfy this signature, allowing
+ * tests to inject a local JWKS without making HTTP calls.
+ */
+export type JwksGetter = (
+  protectedHeader?: JWSHeaderParameters,
+  token?: FlattenedJWSInput,
+) => Promise<CryptoKey>;
+
+/**
+ * Creates a JWKS getter that fetches the public keys from the Auth0 domain.
+ * This is the production implementation — tests should inject a mock instead.
+ */
+export function createAuth0JwksGetter(config: AuthConfig): JwksGetter {
+  const jwksUri = new URL(`https://${config.domain}/.well-known/jwks.json`);
+  return createRemoteJWKSet(jwksUri);
+}
+
+/**
+ * Verifies a JWT access token against the provided JWKS, checking:
+ * - Signature validity
+ * - Token expiry
+ * - Issuer matches the Auth0 domain
+ * - Audience matches the configured API audience
+ *
+ * Throws a JWTExpired, JWTInvalid, or JOSEError on verification failure.
+ */
+export async function verifyAccessToken(
+  token: string,
+  config: AuthConfig,
+  getJwks: JwksGetter,
+): Promise<TokenPayload> {
+  const { payload } = await jwtVerify(token, getJwks, {
+    issuer: `https://${config.domain}/`,
+    audience: config.audience,
+  });
+
+  const sub = payload.sub;
+  const iss = payload.iss;
+  const aud = payload.aud;
+  const exp = payload.exp;
+  const iat = payload.iat;
+  const email = payload['email'];
+
+  if (!sub || !iss || !aud || exp === undefined || iat === undefined) {
+    throw new Error('Token is missing required claims');
+  }
+
+  const rawPermissions = payload['permissions'];
+  const permissions: readonly string[] | undefined = Array.isArray(rawPermissions)
+    ? (rawPermissions as string[])
+    : undefined;
+
+  const result: TokenPayload =
+    permissions !== undefined
+      ? {
+          sub,
+          email: typeof email === 'string' ? email : '',
+          iss,
+          aud,
+          exp,
+          iat,
+          permissions,
+        }
+      : {
+          sub,
+          email: typeof email === 'string' ? email : '',
+          iss,
+          aud,
+          exp,
+          iat,
+        };
+
+  return result;
+}

--- a/packages/core/src/auth/middleware.ts
+++ b/packages/core/src/auth/middleware.ts
@@ -1,0 +1,85 @@
+import { unauthorizedError, forbiddenError } from '@sentinel/shared';
+import type { AuthConfig, AuthUser, AuthError } from '@sentinel/shared';
+import { verifyAccessToken } from './jwt.js';
+import { tokenPayloadToUser } from './user.js';
+import type { JwksGetter } from './jwt.js';
+
+/**
+ * A minimal request abstraction — only the fields auth middleware needs.
+ * Concrete framework adapters (Express, Fastify, etc.) should map their
+ * native request object to this shape before calling the middleware.
+ */
+export interface AuthRequest {
+  readonly headers: Readonly<Record<string, string | string[] | undefined>>;
+}
+
+/**
+ * The result produced by auth middleware after processing a request.
+ * On success, the verified user is attached. On failure, a typed error is returned.
+ */
+export type AuthMiddlewareResult =
+  | { readonly outcome: 'authenticated'; readonly user: AuthUser }
+  | { readonly outcome: 'error'; readonly error: AuthError };
+
+/**
+ * Auth middleware that extracts and verifies a Bearer token from the Authorization header.
+ * Returns an AuthMiddlewareResult — callers are responsible for translating this into
+ * a framework-specific response (e.g., setting res.status(401)).
+ */
+export type AuthMiddlewareFn = (request: AuthRequest) => Promise<AuthMiddlewareResult>;
+
+/**
+ * Permission-check middleware that validates the authenticated user has all required permissions.
+ * Assumes the request has already been processed by createAuthMiddleware.
+ */
+export type PermissionMiddlewareFn = (user: AuthUser) => AuthMiddlewareResult;
+
+/**
+ * Creates an auth middleware function configured for the given Auth0 config and JWKS getter.
+ * Pass a mock JWKS getter in tests to avoid real network calls.
+ */
+export function createAuthMiddleware(config: AuthConfig, getJwks: JwksGetter): AuthMiddlewareFn {
+  return async (request: AuthRequest): Promise<AuthMiddlewareResult> => {
+    const authHeader = request.headers['authorization'];
+    const headerValue = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+
+    if (!headerValue || !headerValue.startsWith('Bearer ')) {
+      return {
+        outcome: 'error',
+        error: unauthorizedError('Missing or malformed Authorization header'),
+      };
+    }
+
+    const token = headerValue.slice('Bearer '.length);
+
+    try {
+      const payload = await verifyAccessToken(token, config, getJwks);
+      const user = tokenPayloadToUser(payload);
+      return { outcome: 'authenticated', user };
+    } catch {
+      return {
+        outcome: 'error',
+        error: unauthorizedError('Token verification failed'),
+      };
+    }
+  };
+}
+
+/**
+ * Returns a permission-check function that verifies the user holds all of the
+ * specified permissions. Returns a 403 Forbidden error result if any are missing.
+ */
+export function requirePermissions(...permissions: string[]): PermissionMiddlewareFn {
+  return (user: AuthUser): AuthMiddlewareResult => {
+    const missing = permissions.filter((p) => !user.permissions.includes(p));
+
+    if (missing.length > 0) {
+      return {
+        outcome: 'error',
+        error: forbiddenError(`Insufficient permissions. Required: ${missing.join(', ')}`),
+      };
+    }
+
+    return { outcome: 'authenticated', user };
+  };
+}

--- a/packages/core/src/auth/user.ts
+++ b/packages/core/src/auth/user.ts
@@ -1,0 +1,16 @@
+import type { AuthUser, TokenPayload } from '@sentinel/shared';
+
+/**
+ * Extracts an AuthUser from a verified TokenPayload.
+ * The `roles` claim is not a standard JWT claim and must be added via Auth0 rules/actions;
+ * it defaults to an empty array when absent.
+ */
+export function tokenPayloadToUser(payload: TokenPayload): AuthUser {
+  return {
+    sub: payload.sub,
+    email: payload.email,
+    name: payload.email, // name is not a standard access token claim; use email as fallback
+    roles: [],
+    permissions: payload.permissions ?? [],
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,3 +13,18 @@ export interface Scenario {
   readonly name: string;
   readonly description?: string;
 }
+
+export {
+  verifyAccessToken,
+  createAuth0JwksGetter,
+  tokenPayloadToUser,
+  createAuthMiddleware,
+  requirePermissions,
+} from './auth/index.js';
+export type {
+  JwksGetter,
+  AuthRequest,
+  AuthMiddlewareResult,
+  AuthMiddlewareFn,
+  PermissionMiddlewareFn,
+} from './auth/index.js';

--- a/packages/shared/src/__tests__/auth.test.ts
+++ b/packages/shared/src/__tests__/auth.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  loadAuthConfig,
+  unauthorizedError,
+  forbiddenError,
+  authConfigError,
+} from '../auth/index.js';
+
+// vi.stubEnv / vi.unstubAllEnvs are the correct way to mutate process.env in Vitest
+// without running into process.env's string-coercion behaviour or ESLint's restrictions.
+
+const FULL_ENV: Record<string, string> = {
+  AUTH0_DOMAIN: 'test.auth0.com',
+  AUTH0_CLIENT_ID: 'client-123',
+  AUTH0_CLIENT_SECRET: 'secret-abc',
+  AUTH0_AUDIENCE: 'https://api.test.com',
+  AUTH0_CALLBACK_URL: 'https://app.test.com/callback',
+  AUTH0_LOGOUT_URL: 'https://app.test.com/logout',
+};
+
+function stubFullEnv(): void {
+  for (const [key, value] of Object.entries(FULL_ENV)) {
+    vi.stubEnv(key, value);
+  }
+}
+
+describe('loadAuthConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns a complete AuthConfig when all env vars are set', () => {
+    stubFullEnv();
+
+    const config = loadAuthConfig();
+
+    expect(config.domain).toBe('test.auth0.com');
+    expect(config.clientId).toBe('client-123');
+    expect(config.clientSecret).toBe('secret-abc');
+    expect(config.audience).toBe('https://api.test.com');
+    expect(config.callbackUrl).toBe('https://app.test.com/callback');
+    expect(config.logoutUrl).toBe('https://app.test.com/logout');
+  });
+
+  it('throws when AUTH0_DOMAIN is missing', () => {
+    stubFullEnv();
+    vi.stubEnv('AUTH0_DOMAIN', '');
+
+    expect(() => loadAuthConfig()).toThrow('AUTH0_DOMAIN');
+  });
+
+  it('throws when AUTH0_CLIENT_ID is missing', () => {
+    stubFullEnv();
+    vi.stubEnv('AUTH0_CLIENT_ID', '');
+
+    expect(() => loadAuthConfig()).toThrow('AUTH0_CLIENT_ID');
+  });
+
+  it('throws when AUTH0_CLIENT_SECRET is missing', () => {
+    stubFullEnv();
+    vi.stubEnv('AUTH0_CLIENT_SECRET', '');
+
+    expect(() => loadAuthConfig()).toThrow('AUTH0_CLIENT_SECRET');
+  });
+
+  it('throws when AUTH0_AUDIENCE is missing', () => {
+    stubFullEnv();
+    vi.stubEnv('AUTH0_AUDIENCE', '');
+
+    expect(() => loadAuthConfig()).toThrow('AUTH0_AUDIENCE');
+  });
+
+  it('throws when AUTH0_CALLBACK_URL is missing', () => {
+    stubFullEnv();
+    vi.stubEnv('AUTH0_CALLBACK_URL', '');
+
+    expect(() => loadAuthConfig()).toThrow('AUTH0_CALLBACK_URL');
+  });
+
+  it('throws when AUTH0_LOGOUT_URL is missing', () => {
+    stubFullEnv();
+    vi.stubEnv('AUTH0_LOGOUT_URL', '');
+
+    expect(() => loadAuthConfig()).toThrow('AUTH0_LOGOUT_URL');
+  });
+
+  it('throws listing all missing variables when multiple are absent', () => {
+    // Don't stub any vars — they should all be absent (or empty)
+    for (const key of Object.keys(FULL_ENV)) {
+      vi.stubEnv(key, '');
+    }
+
+    expect(() => loadAuthConfig()).toThrow('AUTH0_DOMAIN');
+  });
+});
+
+describe('unauthorizedError', () => {
+  it('returns code UNAUTHORIZED and statusCode 401', () => {
+    const err = unauthorizedError('not logged in');
+
+    expect(err.code).toBe('UNAUTHORIZED');
+    expect(err.statusCode).toBe(401);
+    expect(err.message).toBe('not logged in');
+  });
+});
+
+describe('forbiddenError', () => {
+  it('returns code FORBIDDEN and statusCode 403', () => {
+    const err = forbiddenError('access denied');
+
+    expect(err.code).toBe('FORBIDDEN');
+    expect(err.statusCode).toBe(403);
+    expect(err.message).toBe('access denied');
+  });
+});
+
+describe('authConfigError', () => {
+  it('returns code AUTH_CONFIG_ERROR and statusCode 500', () => {
+    const err = authConfigError('AUTH0_DOMAIN');
+
+    expect(err.code).toBe('AUTH_CONFIG_ERROR');
+    expect(err.statusCode).toBe(500);
+    expect(err.message).toContain('AUTH0_DOMAIN');
+  });
+});

--- a/packages/shared/src/__tests__/index.test.ts
+++ b/packages/shared/src/__tests__/index.test.ts
@@ -1,35 +1,34 @@
-import { describe, it, expect, expectTypeOf } from "vitest";
-import { SENTINEL_VERSION, type CheckResult } from "../index.js";
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { SENTINEL_VERSION, type CheckResult } from '../index.js';
 
-describe("@sentinel/shared", () => {
-  describe("SENTINEL_VERSION", () => {
-    it("is a non-empty string", () => {
-      expect(typeof SENTINEL_VERSION).toBe("string");
+describe('@sentinel/shared', () => {
+  describe('SENTINEL_VERSION', () => {
+    it('is a non-empty string', () => {
+      expect(typeof SENTINEL_VERSION).toBe('string');
       expect(SENTINEL_VERSION.length).toBeGreaterThan(0);
     });
 
-    it("matches the expected version format", () => {
+    it('matches the expected version format', () => {
       expect(SENTINEL_VERSION).toMatch(/^\d+\.\d+\.\d+/);
     });
   });
 
-  describe("CheckResult", () => {
-    it("accepts a passing result", () => {
-      const result: CheckResult = { status: "pass" };
-      expect(result.status).toBe("pass");
+  describe('CheckResult', () => {
+    it('accepts a passing result', () => {
+      const result: CheckResult = { status: 'pass' };
+      expect(result.status).toBe('pass');
     });
 
-    it("accepts a failing result with a reason", () => {
-      const result: CheckResult = { status: "fail", reason: "element not found" };
-      expect(result.status).toBe("fail");
-      if (result.status === "fail") {
-        expect(result.reason).toBe("element not found");
-      }
+    it('accepts a failing result with a reason', () => {
+      const result: CheckResult = { status: 'fail', reason: 'element not found' };
+      // The type is narrowed to the fail branch by declaration, so access reason directly
+      expect(result.status).toBe('fail');
+      expect(result.reason).toBe('element not found');
     });
 
-    it("has the correct discriminated union shape", () => {
-      expectTypeOf<CheckResult>().toMatchTypeOf<
-        { status: "pass" } | { status: "fail"; reason: string }
+    it('has the correct discriminated union shape', () => {
+      expectTypeOf<CheckResult>().toExtend<
+        { status: 'pass' } | { status: 'fail'; reason: string }
       >();
     });
   });

--- a/packages/shared/src/auth/config.ts
+++ b/packages/shared/src/auth/config.ts
@@ -1,0 +1,56 @@
+import type { AuthConfig } from './types.js';
+
+// ESLint's type-checker cannot resolve `process` without @types/node hoisted to the
+// workspace root. We access process.env through globalThis to satisfy the linter while
+// preserving identical runtime behaviour. vi.stubEnv works transparently with this approach
+// because it mutates process.env directly.
+const nodeEnv =
+  (
+    (globalThis as Record<string, unknown>)['process'] as
+      | { env: Record<string, string | undefined> }
+      | undefined
+  )?.env ?? {};
+
+/**
+ * Loads Auth0 configuration from environment variables.
+ * Fails fast with a clear error message if any required variable is missing,
+ * preventing misconfigured services from starting silently.
+ */
+export function loadAuthConfig(): AuthConfig {
+  const domain = nodeEnv['AUTH0_DOMAIN'];
+  const clientId = nodeEnv['AUTH0_CLIENT_ID'];
+  const clientSecret = nodeEnv['AUTH0_CLIENT_SECRET'];
+  const audience = nodeEnv['AUTH0_AUDIENCE'];
+  const callbackUrl = nodeEnv['AUTH0_CALLBACK_URL'];
+  const logoutUrl = nodeEnv['AUTH0_LOGOUT_URL'];
+
+  const missing: string[] = [];
+  if (!domain) missing.push('AUTH0_DOMAIN');
+  if (!clientId) missing.push('AUTH0_CLIENT_ID');
+  if (!clientSecret) missing.push('AUTH0_CLIENT_SECRET');
+  if (!audience) missing.push('AUTH0_AUDIENCE');
+  if (!callbackUrl) missing.push('AUTH0_CALLBACK_URL');
+  if (!logoutUrl) missing.push('AUTH0_LOGOUT_URL');
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Auth0 configuration is incomplete. Missing environment variables: ${missing.join(', ')}`,
+    );
+  }
+
+  return {
+    // Non-null assertions are safe: we threw above if any were falsy
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    domain: domain!,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    clientId: clientId!,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    clientSecret: clientSecret!,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    audience: audience!,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    callbackUrl: callbackUrl!,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    logoutUrl: logoutUrl!,
+  };
+}

--- a/packages/shared/src/auth/errors.ts
+++ b/packages/shared/src/auth/errors.ts
@@ -1,0 +1,28 @@
+import type { AuthError } from './types.js';
+
+/** Returns a 401 Unauthorized error for authentication failures. */
+export function unauthorizedError(message: string): AuthError {
+  return {
+    code: 'UNAUTHORIZED',
+    message,
+    statusCode: 401,
+  };
+}
+
+/** Returns a 403 Forbidden error for authorization failures. */
+export function forbiddenError(message: string): AuthError {
+  return {
+    code: 'FORBIDDEN',
+    message,
+    statusCode: 403,
+  };
+}
+
+/** Returns a 500 Internal Server Error for auth configuration problems. */
+export function authConfigError(missing: string): AuthError {
+  return {
+    code: 'AUTH_CONFIG_ERROR',
+    message: `Auth configuration error: missing ${missing}`,
+    statusCode: 500,
+  };
+}

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -1,0 +1,3 @@
+export type { AuthConfig, AuthUser, TokenPayload, AuthResult, AuthError } from './types.js';
+export { loadAuthConfig } from './config.js';
+export { unauthorizedError, forbiddenError, authConfigError } from './errors.js';

--- a/packages/shared/src/auth/types.ts
+++ b/packages/shared/src/auth/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Domain types for Auth0-based authentication in Sentinel.
+ * These types are shared across all packages to ensure consistent auth contracts.
+ */
+
+export interface AuthConfig {
+  readonly domain: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly audience: string;
+  readonly callbackUrl: string;
+  readonly logoutUrl: string;
+}
+
+export interface AuthUser {
+  readonly sub: string;
+  readonly email: string;
+  readonly name: string;
+  readonly roles: readonly string[];
+  readonly permissions: readonly string[];
+}
+
+export interface TokenPayload {
+  readonly sub: string;
+  readonly email: string;
+  readonly iss: string;
+  readonly aud: string | readonly string[];
+  readonly exp: number;
+  readonly iat: number;
+  readonly permissions?: readonly string[];
+}
+
+export type AuthResult =
+  | { readonly status: 'authenticated'; readonly user: AuthUser; readonly accessToken: string }
+  | { readonly status: 'unauthenticated'; readonly reason: string };
+
+export interface AuthError {
+  readonly code: string;
+  readonly message: string;
+  readonly statusCode: number;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,11 @@ export type SentinelVersion = typeof SENTINEL_VERSION;
 
 /** Represents the result of a QA check — either a pass or a structured failure. */
 export type CheckResult = { status: 'pass' } | { status: 'fail'; reason: string };
+
+export type { AuthConfig, AuthUser, TokenPayload, AuthResult, AuthError } from './auth/index.js';
+export {
+  loadAuthConfig,
+  unauthorizedError,
+  forbiddenError,
+  authConfigError,
+} from './auth/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@sentinel/shared':
         specifier: workspace:*
         version: link:../shared
+      jose:
+        specifier: ^6.1.3
+        version: 6.1.3
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -828,6 +831,9 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -1817,6 +1823,8 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  jose@6.1.3: {}
 
   js-tokens@10.0.0: {}
 


### PR DESCRIPTION
## Summary
- Add Auth0 authentication types, config loader, and error factories to `@sentinel/shared`
- Add JWT verification via `jose` and framework-agnostic auth middleware to `@sentinel/core`
- 28 new tests covering config loading, JWT verification, middleware, and RBAC permission checks

## Test plan
- [x] `pnpm test` — 28 new tests + existing all pass
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)