### PR TITLE
feat(auth): add JWT session management with token refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,12 @@ sentinel/
 ├── packages/
 │   ├── shared/           # @sentinel/shared — shared types and utilities (no internal deps)
 │   │   └── src/
-│   │       ├── index.ts          # Public API: version constants, CheckResult, auth types/config/errors
+│   │       ├── index.ts          # Public API: version constants, CheckResult, auth types/config/errors/session
 │   │       ├── auth/
 │   │       │   ├── types.ts      # AuthConfig, AuthUser, TokenPayload, AuthResult, AuthError interfaces
 │   │       │   ├── config.ts     # loadAuthConfig() — reads Auth0 env vars, throws on missing
 │   │       │   ├── errors.ts     # unauthorizedError, forbiddenError, authConfigError factories
+│   │       │   ├── session.ts    # SessionConfig, TokenSet, TokenRefreshResult, WorkerTokenRequest, WorkerToken
 │   │       │   └── index.ts      # Barrel re-export for auth/
 │   │       └── __tests__/
 │   │           ├── index.test.ts # Unit tests for shared exports
@@ -31,10 +32,12 @@ sentinel/
 │   │       │   ├── jwt.ts        # verifyAccessToken(), createAuth0JwksGetter(), JwksGetter type
 │   │       │   ├── middleware.ts  # createAuthMiddleware(), requirePermissions() — framework-agnostic
 │   │       │   ├── user.ts       # tokenPayloadToUser() — maps TokenPayload to AuthUser
+│   │       │   ├── session.ts    # SessionManager class, createAuth0TokenExchanger(), TokenExchanger type
 │   │       │   └── index.ts      # Barrel re-export for auth/
 │   │       └── __tests__/
-│   │           ├── index.test.ts # Unit tests for core exports
-│   │           └── auth.test.ts  # Unit tests for JWT verification and auth middleware
+│   │           ├── index.test.ts  # Unit tests for core exports
+│   │           ├── auth.test.ts   # Unit tests for JWT verification and auth middleware
+│   │           └── session.test.ts # Unit tests for SessionManager (createTokenSet, refresh, needsRefresh, etc.)
 │   ├── cli/              # @sentinel/cli — command-line interface entry point
 │   │   └── src/
 │   │       ├── index.ts          # Public API: CLI_NAME, re-exports from core/shared

--- a/packages/core/src/__tests__/session.test.ts
+++ b/packages/core/src/__tests__/session.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { AuthConfig } from '@sentinel/shared';
+import type { SessionConfig, TokenSet } from '@sentinel/shared';
+import { SessionManager } from '../auth/session.js';
+import type { TokenExchanger } from '../auth/session.js';
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_CONFIG: AuthConfig = {
+  domain: 'test.auth0.com',
+  clientId: 'client-123',
+  clientSecret: 'secret-abc',
+  audience: 'https://api.test.com',
+  callbackUrl: 'https://app.test.com/callback',
+  logoutUrl: 'https://app.test.com/logout',
+};
+
+const SESSION_CONFIG: SessionConfig = {
+  accessTokenTtlSeconds: 3600,
+  refreshBufferSeconds: 300,
+};
+
+function makeTokenSet(overrides: Partial<TokenSet> = {}): TokenSet {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return {
+    accessToken: 'access-token-value',
+    refreshToken: 'refresh-token-value',
+    expiresAt: nowSeconds + 3600,
+    ...overrides,
+  };
+}
+
+function makeExchanger(result: TokenSet): TokenExchanger {
+  return vi.fn().mockResolvedValue(result);
+}
+
+function makeFailingExchanger(message: string): TokenExchanger {
+  return vi.fn().mockRejectedValue(new Error(message));
+}
+
+// ---------------------------------------------------------------------------
+// createTokenSet
+// ---------------------------------------------------------------------------
+
+describe('SessionManager.createTokenSet', () => {
+  it('calls the token exchanger with authorization_code grant and correct params', async () => {
+    const expected = makeTokenSet({ accessToken: 'new-access-token' });
+    const exchanger = makeExchanger(expected);
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, exchanger);
+
+    const result = await manager.createTokenSet('auth-code-xyz', 'https://app.test.com/callback');
+
+    expect(exchanger).toHaveBeenCalledWith('authorization_code', {
+      code: 'auth-code-xyz',
+      redirect_uri: 'https://app.test.com/callback',
+    });
+    expect(result).toBe(expected);
+  });
+
+  it('returns the TokenSet produced by the exchanger', async () => {
+    const expected = makeTokenSet({ accessToken: 'returned-token' });
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(expected));
+
+    const result = await manager.createTokenSet('code', 'https://app.test.com/callback');
+
+    expect(result.accessToken).toBe('returned-token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshTokenSet
+// ---------------------------------------------------------------------------
+
+describe('SessionManager.refreshTokenSet', () => {
+  it('returns refreshed status with new token set on success', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const refreshed = makeTokenSet({
+      accessToken: 'refreshed-token',
+      expiresAt: nowSeconds + 7200,
+    });
+    const existing = makeTokenSet();
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(refreshed));
+
+    const result = await manager.refreshTokenSet(existing);
+
+    expect(result.status).toBe('refreshed');
+    if (result.status === 'refreshed') {
+      expect(result.tokenSet.accessToken).toBe('refreshed-token');
+    }
+  });
+
+  it('calls token exchanger with refresh_token grant and the existing refresh token', async () => {
+    const existing = makeTokenSet({ refreshToken: 'my-refresh-token' });
+    const exchanger = makeExchanger(makeTokenSet());
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, exchanger);
+
+    await manager.refreshTokenSet(existing);
+
+    expect(exchanger).toHaveBeenCalledWith('refresh_token', {
+      refresh_token: 'my-refresh-token',
+    });
+  });
+
+  it('returns expired status with reason when exchanger throws', async () => {
+    const existing = makeTokenSet();
+    const manager = new SessionManager(
+      TEST_CONFIG,
+      SESSION_CONFIG,
+      makeFailingExchanger('invalid_grant: Token has been expired or revoked'),
+    );
+
+    const result = await manager.refreshTokenSet(existing);
+
+    expect(result.status).toBe('expired');
+    if (result.status === 'expired') {
+      expect(result.reason).toBe('invalid_grant: Token has been expired or revoked');
+    }
+  });
+
+  it('returns expired status with a fallback reason when the thrown value is not an Error', async () => {
+    const existing = makeTokenSet();
+    const exchanger: TokenExchanger = vi.fn().mockRejectedValue('some string error');
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, exchanger);
+
+    const result = await manager.refreshTokenSet(existing);
+
+    expect(result.status).toBe('expired');
+    if (result.status === 'expired') {
+      expect(result.reason).toBe('Refresh token rejected or expired');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// needsRefresh
+// ---------------------------------------------------------------------------
+
+describe('SessionManager.needsRefresh', () => {
+  it('returns true when the token expires within the refresh buffer window', () => {
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(makeTokenSet()));
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    // expires in 200 seconds, buffer is 300 — should trigger refresh
+    const tokenSet = makeTokenSet({ expiresAt: nowSeconds + 200 });
+
+    expect(manager.needsRefresh(tokenSet)).toBe(true);
+  });
+
+  it('returns true when the token expires exactly at the buffer boundary', () => {
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(makeTokenSet()));
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    // expires in exactly 300 seconds — at the boundary, should trigger refresh
+    const tokenSet = makeTokenSet({ expiresAt: nowSeconds + SESSION_CONFIG.refreshBufferSeconds });
+
+    expect(manager.needsRefresh(tokenSet)).toBe(true);
+  });
+
+  it('returns false when the token has ample time remaining before the buffer', () => {
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(makeTokenSet()));
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    // expires in 3600 seconds, buffer is 300 — plenty of time
+    const tokenSet = makeTokenSet({ expiresAt: nowSeconds + 3600 });
+
+    expect(manager.needsRefresh(tokenSet)).toBe(false);
+  });
+
+  it('returns true for an already-expired token', () => {
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(makeTokenSet()));
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const tokenSet = makeTokenSet({ expiresAt: nowSeconds - 60 });
+
+    expect(manager.needsRefresh(tokenSet)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isExpired
+// ---------------------------------------------------------------------------
+
+describe('SessionManager.isExpired', () => {
+  it('returns true when the access token expiry has passed', () => {
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(makeTokenSet()));
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const tokenSet = makeTokenSet({ expiresAt: nowSeconds - 1 });
+
+    expect(manager.isExpired(tokenSet)).toBe(true);
+  });
+
+  it('returns false when the access token is still valid', () => {
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(makeTokenSet()));
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const tokenSet = makeTokenSet({ expiresAt: nowSeconds + 3600 });
+
+    expect(manager.isExpired(tokenSet)).toBe(false);
+  });
+
+  it('returns true for a token that expires exactly now', () => {
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(makeTokenSet()));
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const tokenSet = makeTokenSet({ expiresAt: nowSeconds });
+
+    expect(manager.isExpired(tokenSet)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createWorkerToken
+// ---------------------------------------------------------------------------
+
+describe('SessionManager.createWorkerToken', () => {
+  it('returns a WorkerToken with the correct worker ID and expiry from the exchanger', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const workerTokenSet = makeTokenSet({
+      accessToken: 'worker-access-token',
+      expiresAt: nowSeconds + 900,
+    });
+    const exchanger = makeExchanger(workerTokenSet);
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, exchanger);
+
+    const tokenSet = makeTokenSet();
+    const result = await manager.createWorkerToken(tokenSet, {
+      workerId: 'worker-abc',
+      scopes: ['run:scenarios', 'read:results'],
+    });
+
+    expect(result.workerId).toBe('worker-abc');
+    expect(result.accessToken).toBe('worker-access-token');
+    expect(result.expiresAt).toBe(nowSeconds + 900);
+  });
+
+  it('calls the exchanger with token-exchange grant, subject token, and joined scopes', async () => {
+    const exchanger = makeExchanger(makeTokenSet());
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, exchanger);
+
+    const tokenSet = makeTokenSet({ accessToken: 'subject-token' });
+    await manager.createWorkerToken(tokenSet, {
+      workerId: 'worker-xyz',
+      scopes: ['run:scenarios', 'read:results'],
+    });
+
+    expect(exchanger).toHaveBeenCalledWith(
+      'urn:ietf:params:oauth:grant-type:token-exchange',
+      expect.objectContaining({
+        subject_token: 'subject-token',
+        subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        scope: 'run:scenarios read:results',
+        worker_id: 'worker-xyz',
+      }),
+    );
+  });
+
+  it('uses only the access token from the returned TokenSet as the worker access token', async () => {
+    const workerTokenSet = makeTokenSet({ accessToken: 'scoped-worker-token' });
+    const manager = new SessionManager(TEST_CONFIG, SESSION_CONFIG, makeExchanger(workerTokenSet));
+
+    const result = await manager.createWorkerToken(makeTokenSet(), {
+      workerId: 'worker-1',
+      scopes: ['run:scenarios'],
+    });
+
+    expect(result.accessToken).toBe('scoped-worker-token');
+  });
+});

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -8,3 +8,5 @@ export type {
   AuthMiddlewareFn,
   PermissionMiddlewareFn,
 } from './middleware.js';
+export { SessionManager, createAuth0TokenExchanger } from './session.js';
+export type { TokenExchanger } from './session.js';

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -1,0 +1,153 @@
+import type { AuthConfig } from '@sentinel/shared';
+import type {
+  SessionConfig,
+  TokenSet,
+  TokenRefreshResult,
+  WorkerTokenRequest,
+  WorkerToken,
+} from '@sentinel/shared';
+
+/**
+ * A dependency-injectable token exchange function.
+ * Abstracts calls to Auth0's /oauth/token endpoint so that tests can mock the exchange
+ * without making real HTTP calls.
+ *
+ * @param grantType - The OAuth2 grant type (e.g. 'authorization_code', 'refresh_token')
+ * @param params - Grant-specific parameters (code, redirect_uri, refresh_token, etc.)
+ * @returns A resolved TokenSet on success, or throws on failure.
+ */
+export type TokenExchanger = (
+  grantType: string,
+  params: Record<string, string>,
+) => Promise<TokenSet>;
+
+/**
+ * Manages the lifecycle of Auth0 JWT sessions: exchanging authorization codes for tokens,
+ * refreshing expiring access tokens, and minting short-lived worker tokens.
+ */
+export class SessionManager {
+  private readonly config: AuthConfig;
+  private readonly sessionConfig: SessionConfig;
+  private readonly tokenExchanger: TokenExchanger;
+
+  constructor(config: AuthConfig, sessionConfig: SessionConfig, tokenExchanger: TokenExchanger) {
+    this.config = config;
+    this.sessionConfig = sessionConfig;
+    this.tokenExchanger = tokenExchanger;
+  }
+
+  /**
+   * Exchanges an authorization code for a TokenSet via the authorization_code grant.
+   * Called after the Auth0 redirect completes and the code is received.
+   */
+  async createTokenSet(authorizationCode: string, redirectUri: string): Promise<TokenSet> {
+    return this.tokenExchanger('authorization_code', {
+      code: authorizationCode,
+      redirect_uri: redirectUri,
+    });
+  }
+
+  /**
+   * Uses the refresh token to obtain a new access token.
+   * Returns 'expired' when the refresh token is no longer accepted by Auth0,
+   * signalling that the user must re-authenticate.
+   */
+  async refreshTokenSet(tokenSet: TokenSet): Promise<TokenRefreshResult> {
+    try {
+      const refreshed = await this.tokenExchanger('refresh_token', {
+        refresh_token: tokenSet.refreshToken,
+      });
+      return { status: 'refreshed', tokenSet: refreshed };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'Refresh token rejected or expired';
+      return { status: 'expired', reason };
+    }
+  }
+
+  /**
+   * Returns true when the access token will expire within the configured refresh buffer window.
+   * Use this to trigger a proactive refresh before the token actually expires.
+   */
+  needsRefresh(tokenSet: TokenSet): boolean {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    return tokenSet.expiresAt - nowSeconds <= this.sessionConfig.refreshBufferSeconds;
+  }
+
+  /**
+   * Returns true when the access token's expiry time has already passed.
+   */
+  isExpired(tokenSet: TokenSet): boolean {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    return tokenSet.expiresAt <= nowSeconds;
+  }
+
+  /**
+   * Creates a short-lived, narrowly-scoped token for a browser worker.
+   * Delegates to the token exchanger using the urn:ietf:params:oauth:grant-type:token-exchange
+   * grant so that Auth0 can enforce scope restrictions on the resulting token.
+   */
+  async createWorkerToken(tokenSet: TokenSet, request: WorkerTokenRequest): Promise<WorkerToken> {
+    const workerTokenSet = await this.tokenExchanger(
+      'urn:ietf:params:oauth:grant-type:token-exchange',
+      {
+        subject_token: tokenSet.accessToken,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        scope: request.scopes.join(' '),
+        worker_id: request.workerId,
+      },
+    );
+
+    return {
+      accessToken: workerTokenSet.accessToken,
+      workerId: request.workerId,
+      expiresAt: workerTokenSet.expiresAt,
+    };
+  }
+}
+
+/**
+ * The production token exchanger — calls Auth0's /oauth/token endpoint via Node's built-in fetch.
+ * Inject this into SessionManager for real deployments; use a mock in tests.
+ */
+export function createAuth0TokenExchanger(config: AuthConfig): TokenExchanger {
+  return async (grantType: string, params: Record<string, string>): Promise<TokenSet> => {
+    const url = `https://${config.domain}/oauth/token`;
+
+    const body = new URLSearchParams({
+      grant_type: grantType,
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      audience: config.audience,
+      ...params,
+    });
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Auth0 token exchange failed (${response.status.toString()}): ${text}`);
+    }
+
+    const data = (await response.json()) as {
+      access_token: string;
+      refresh_token?: string;
+      id_token?: string;
+      expires_in: number;
+    };
+
+    const expiresAt = Math.floor(Date.now() / 1000) + data.expires_in;
+
+    const tokenSet: TokenSet = {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token ?? '',
+      expiresAt,
+      ...(data.id_token !== undefined ? { idToken: data.id_token } : {}),
+    };
+
+    return tokenSet;
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,8 @@ export {
   tokenPayloadToUser,
   createAuthMiddleware,
   requirePermissions,
+  SessionManager,
+  createAuth0TokenExchanger,
 } from './auth/index.js';
 export type {
   JwksGetter,
@@ -27,4 +29,5 @@ export type {
   AuthMiddlewareResult,
   AuthMiddlewareFn,
   PermissionMiddlewareFn,
+  TokenExchanger,
 } from './auth/index.js';

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -1,3 +1,10 @@
 export type { AuthConfig, AuthUser, TokenPayload, AuthResult, AuthError } from './types.js';
 export { loadAuthConfig } from './config.js';
 export { unauthorizedError, forbiddenError, authConfigError } from './errors.js';
+export type {
+  SessionConfig,
+  TokenSet,
+  TokenRefreshResult,
+  WorkerTokenRequest,
+  WorkerToken,
+} from './session.js';

--- a/packages/shared/src/auth/session.ts
+++ b/packages/shared/src/auth/session.ts
@@ -1,0 +1,35 @@
+/**
+ * Session management types for JWT-based auth in Sentinel.
+ * These types are shared across all packages that participate in session lifecycle.
+ */
+
+export interface SessionConfig {
+  /** Expected access token TTL in seconds — used to calculate preemptive refresh timing. */
+  readonly accessTokenTtlSeconds: number;
+  /** Trigger a refresh this many seconds before the access token expires. */
+  readonly refreshBufferSeconds: number;
+}
+
+export interface TokenSet {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  /** Unix timestamp (seconds) at which the access token expires. */
+  readonly expiresAt: number;
+  readonly idToken?: string;
+}
+
+export type TokenRefreshResult =
+  | { readonly status: 'refreshed'; readonly tokenSet: TokenSet }
+  | { readonly status: 'expired'; readonly reason: string };
+
+export interface WorkerTokenRequest {
+  readonly workerId: string;
+  readonly scopes: readonly string[];
+}
+
+export interface WorkerToken {
+  readonly accessToken: string;
+  readonly workerId: string;
+  /** Unix timestamp (seconds) at which the worker token expires. */
+  readonly expiresAt: number;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,3 +18,10 @@ export {
   forbiddenError,
   authConfigError,
 } from './auth/index.js';
+export type {
+  SessionConfig,
+  TokenSet,
+  TokenRefreshResult,
+  WorkerTokenRequest,
+  WorkerToken,
+} from './auth/index.js';


### PR DESCRIPTION
## Summary
- Add session types (`TokenSet`, `SessionConfig`, `TokenRefreshResult`, `WorkerToken`) to `@sentinel/shared`
- Add `SessionManager` class with token exchange, refresh, expiry detection, and worker token creation to `@sentinel/core`
- Add `createAuth0TokenExchanger` for production Auth0 `/oauth/token` integration
- 16 new tests covering all session management methods

## Test plan
- [x] `pnpm test` — all tests pass
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)