### PR TITLE
feat(auth): add MFA enforcement and error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,27 +17,31 @@ sentinel/
 │   │   └── src/
 │   │       ├── index.ts          # Public API: version constants, CheckResult, auth types/config/errors/session
 │   │       ├── auth/
-│   │       │   ├── types.ts      # AuthConfig, AuthUser, TokenPayload, AuthResult, AuthError interfaces
+│   │       │   ├── types.ts      # AuthConfig, AuthUser, TokenPayload (incl. amr), AuthResult, AuthError
 │   │       │   ├── config.ts     # loadAuthConfig() — reads Auth0 env vars, throws on missing
 │   │       │   ├── errors.ts     # unauthorizedError, forbiddenError, authConfigError factories
 │   │       │   ├── session.ts    # SessionConfig, TokenSet, TokenRefreshResult, WorkerTokenRequest, WorkerToken
+│   │       │   ├── mfa.ts        # MFA_ERROR_CODES, MfaErrorCode, MfaError, MfaChallengeResult, isMfaError, createMfaError
 │   │       │   └── index.ts      # Barrel re-export for auth/
 │   │       └── __tests__/
 │   │           ├── index.test.ts # Unit tests for shared exports
-│   │           └── auth.test.ts  # Unit tests for auth config loading and error factories
+│   │           ├── auth.test.ts  # Unit tests for auth config loading and error factories
+│   │           └── mfa.test.ts   # Unit tests for MFA error types and helpers
 │   ├── core/             # @sentinel/core — domain models and core business logic
 │   │   └── src/
 │   │       ├── index.ts          # Public API: Scenario interface, auth modules, re-exports from shared
 │   │       ├── auth/
-│   │       │   ├── jwt.ts        # verifyAccessToken(), createAuth0JwksGetter(), JwksGetter type
+│   │       │   ├── jwt.ts        # verifyAccessToken() (extracts amr claim), createAuth0JwksGetter(), JwksGetter type
 │   │       │   ├── middleware.ts  # createAuthMiddleware(), requirePermissions() — framework-agnostic
+│   │       │   ├── mfa.ts        # createMfaEnforcementMiddleware(), parseMfaErrorResponse()
 │   │       │   ├── user.ts       # tokenPayloadToUser() — maps TokenPayload to AuthUser
 │   │       │   ├── session.ts    # SessionManager class, createAuth0TokenExchanger(), TokenExchanger type
 │   │       │   └── index.ts      # Barrel re-export for auth/
 │   │       └── __tests__/
 │   │           ├── index.test.ts  # Unit tests for core exports
 │   │           ├── auth.test.ts   # Unit tests for JWT verification and auth middleware
-│   │           └── session.test.ts # Unit tests for SessionManager (createTokenSet, refresh, needsRefresh, etc.)
+│   │           ├── session.test.ts # Unit tests for SessionManager (createTokenSet, refresh, needsRefresh, etc.)
+│   │           └── mfa.test.ts   # Unit tests for MFA enforcement middleware and response parsing
 │   ├── cli/              # @sentinel/cli — command-line interface entry point
 │   │   └── src/
 │   │       ├── index.ts          # Public API: CLI_NAME, re-exports from core/shared
@@ -48,6 +52,8 @@ sentinel/
 │           ├── index.ts          # Public API: APP_TITLE, re-exports from core/shared
 │           └── __tests__/
 │               └── index.test.ts # Unit tests for web exports
+├── docs/
+│   └── auth0-mfa-setup.md  # Auth0 MFA configuration guide and Sentinel error-handling reference
 ├── Dockerfile            # Multi-stage build: base → deps → build → api → web
 ├── docker-compose.yml    # Full local stack: api, web, browser-worker, redis, postgres
 ├── .dockerignore         # Excludes node_modules, dist, .git, .env, .claude, coverage

--- a/docs/auth0-mfa-setup.md
+++ b/docs/auth0-mfa-setup.md
@@ -1,0 +1,106 @@
+# Auth0 MFA Setup for Sentinel
+
+This document describes how to configure multi-factor authentication (MFA) enforcement in your Auth0 tenant for use with Sentinel, and explains how Sentinel handles MFA errors at runtime.
+
+## Enabling MFA in Auth0
+
+1. Log in to the [Auth0 Dashboard](https://manage.auth0.com).
+2. Navigate to **Security > Multi-factor Auth**.
+3. Enable MFA for your tenant by toggling the switch to **On**.
+4. Select the MFA factors you want to make available to users.
+
+## Recommended MFA Factors
+
+Auth0 supports several MFA factors. The following are recommended for Sentinel:
+
+- **Auth0 Guardian** — a push notification app maintained by Auth0. It provides a good user experience and supports biometric approval on mobile devices. This is the preferred option for user-facing applications.
+- **TOTP (Time-based One-Time Password)** — compatible with authenticator apps such as Google Authenticator, Authy, and 1Password. Use this as a fallback or as an option for users who prefer hardware tokens or existing authenticator setups.
+
+Do not use SMS OTP as a primary factor in high-assurance environments. SMS is susceptible to SIM-swapping attacks. If SMS is offered, treat it as a second-choice fallback rather than a default.
+
+## Configuring MFA Policies
+
+Auth0 supports two main policy modes for MFA enforcement:
+
+### Always require MFA
+
+All users must complete MFA on every login, regardless of context.
+
+In the Auth0 Dashboard, under **Security > Multi-factor Auth**, set the policy to **Always**.
+
+This is the recommended setting for Sentinel's production environment and any environment where sensitive QA data or automation credentials are accessible.
+
+### Adaptive MFA (risk-based)
+
+Auth0 can apply MFA selectively based on signals such as unusual login location, new device, or unusual access patterns.
+
+In the Auth0 Dashboard, under **Security > Multi-factor Auth**, set the policy to **Adaptive**. Review and configure the risk factors to match your organization's threat model.
+
+Note that adaptive MFA does not guarantee that every token carries an `amr: ["mfa"]` claim, because some low-risk sessions will not trigger an MFA challenge. If Sentinel requires unconditional MFA enforcement, use the **Always** policy.
+
+### Requiring MFA for specific APIs via Auth0 Actions
+
+For finer-grained control, use an Auth0 Action in the **Login flow** to conditionally require MFA based on the requested audience or application:
+
+```javascript
+exports.onExecutePostLogin = async (event, api) => {
+  if (event.resource_server?.identifier === 'https://api.yoursentineldomain.com') {
+    api.multifactor.enable('any');
+  }
+};
+```
+
+This ensures that MFA is only enforced for token requests targeting the Sentinel API, without affecting other applications on the same tenant.
+
+## How Sentinel Handles MFA Errors
+
+### Token inspection
+
+After a user authenticates and obtains an access token, Sentinel inspects the token's `amr` (Authentication Methods Reference) claim. When MFA was completed during the login flow, Auth0 includes `"mfa"` in the `amr` array.
+
+Sentinel's `createMfaEnforcementMiddleware` (in `@sentinel/core`) inspects the `amr` claim:
+
+- If `amr` includes `"mfa"`, the request is allowed to proceed.
+- If `amr` is absent or does not contain `"mfa"`, the middleware returns a `MfaChallengeResult` with status `"required"`.
+
+### OAuth token exchange errors
+
+When a client application attempts to exchange an authorization code or refresh token for an access token and Auth0 requires MFA, Auth0 returns a structured error body:
+
+```json
+{
+  "error": "mfa_required",
+  "mfa_token": "<short-lived-mfa-token>",
+  "error_description": "MFA is required"
+}
+```
+
+Sentinel's `parseMfaErrorResponse` (in `@sentinel/core`) converts this raw response body into a typed `MfaChallengeResult`. Clients should pass the `mfa_token` back to Auth0's `/mfa/challenge` endpoint to begin the MFA flow.
+
+### MFA error codes
+
+Sentinel defines the following MFA error codes in `MFA_ERROR_CODES` (exported from `@sentinel/shared`):
+
+| Code                      | Meaning                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| `mfa_required`            | The user must complete an MFA challenge before a token can be issued.          |
+| `mfa_enrollment_required` | The user has not enrolled any MFA factors. They must enroll before logging in. |
+| `mfa_token_invalid`       | The MFA token presented is expired or has already been used.                   |
+| `mfa_factor_not_enrolled` | The requested MFA factor is not enrolled for this user.                        |
+
+### Enrollment redirect
+
+When Auth0 returns `mfa_enrollment_required`, it may include an `enrollment_url` in the response. Clients should redirect users to this URL to complete factor enrollment. After enrollment, the user can retry the login flow.
+
+If no `enrollment_url` is available, redirect users to your Auth0 Universal Login page or your organization's MFA enrollment documentation.
+
+## Testing MFA Locally
+
+Auth0 provides a way to test MFA in development without a real device:
+
+1. In the Auth0 Dashboard, go to **Security > Multi-factor Auth**.
+2. Enable the **OTP** factor (TOTP).
+3. Use an authenticator app to scan the QR code shown during enrollment on your local user account.
+4. Log in with your test account and complete the TOTP challenge to obtain a token with `amr: ["mfa"]`.
+
+Alternatively, use Auth0's **Try** button on the application settings page to simulate a login and inspect the resulting token payload in the Auth0 logs.

--- a/packages/core/src/__tests__/mfa.test.ts
+++ b/packages/core/src/__tests__/mfa.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { MFA_ERROR_CODES, isMfaError, createMfaError } from '@sentinel/shared';
+import type { AuthError, AuthUser } from '@sentinel/shared';
+import { createMfaEnforcementMiddleware, parseMfaErrorResponse } from '../auth/mfa.js';
+import type { AuthMiddlewareResult } from '../auth/middleware.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — build AuthMiddlewareResult fixtures without network or crypto
+// ---------------------------------------------------------------------------
+
+function authenticatedResult(user?: Partial<AuthUser>): AuthMiddlewareResult {
+  return {
+    outcome: 'authenticated',
+    user: {
+      sub: 'user|123',
+      email: 'test@example.com',
+      name: 'test@example.com',
+      roles: [],
+      permissions: [],
+      ...user,
+    },
+  };
+}
+
+function errorResult(error: AuthError): AuthMiddlewareResult {
+  return { outcome: 'error', error };
+}
+
+// ---------------------------------------------------------------------------
+// isMfaError (re-tested here at the integration level to confirm cross-package
+// re-exports work correctly; the detailed unit tests live in @sentinel/shared)
+// ---------------------------------------------------------------------------
+
+describe('isMfaError', () => {
+  it('correctly identifies an MFA error', () => {
+    const mfaErr = createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, 'MFA required');
+    expect(isMfaError(mfaErr)).toBe(true);
+  });
+
+  it('returns false for a non-MFA AuthError', () => {
+    const authErr: AuthError = { code: 'UNAUTHORIZED', message: 'Not logged in', statusCode: 401 };
+    expect(isMfaError(authErr)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMfaError (cross-package re-export smoke test)
+// ---------------------------------------------------------------------------
+
+describe('createMfaError', () => {
+  it('produces an MfaError with the correct shape', () => {
+    const err = createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, 'MFA is required', 'tok-abc');
+
+    expect(err.code).toBe('mfa_required');
+    expect(err.message).toBe('MFA is required');
+    expect(err.statusCode).toBe(403);
+    expect(err.mfaToken).toBe('tok-abc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMfaEnforcementMiddleware
+// ---------------------------------------------------------------------------
+
+describe('createMfaEnforcementMiddleware', () => {
+  const enforce = createMfaEnforcementMiddleware();
+
+  it("returns 'completed' when the amr claim includes 'mfa'", () => {
+    const result = authenticatedResult();
+    const outcome = enforce(result, ['mfa']);
+
+    expect(outcome.status).toBe('completed');
+  });
+
+  it("returns 'completed' when amr contains 'mfa' alongside other methods", () => {
+    const result = authenticatedResult();
+    const outcome = enforce(result, ['pwd', 'mfa']);
+
+    expect(outcome.status).toBe('completed');
+  });
+
+  it("returns 'required' when amr is absent", () => {
+    const result = authenticatedResult();
+    const outcome = enforce(result, undefined);
+
+    expect(outcome.status).toBe('required');
+    if (outcome.status === 'required') {
+      expect(outcome.error.code).toBe(MFA_ERROR_CODES.MFA_REQUIRED);
+    }
+  });
+
+  it("returns 'required' when amr does not include 'mfa'", () => {
+    const result = authenticatedResult();
+    const outcome = enforce(result, ['pwd']);
+
+    expect(outcome.status).toBe('required');
+    if (outcome.status === 'required') {
+      expect(outcome.error.code).toBe(MFA_ERROR_CODES.MFA_REQUIRED);
+    }
+  });
+
+  it("returns 'required' for an auth error result with an MFA error", () => {
+    const mfaError = createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, 'MFA needed', 'mfa-tok');
+    const result = errorResult(mfaError);
+    const outcome = enforce(result);
+
+    expect(outcome.status).toBe('required');
+    if (outcome.status === 'required') {
+      expect(outcome.error.code).toBe(MFA_ERROR_CODES.MFA_REQUIRED);
+      expect(outcome.error.mfaToken).toBe('mfa-tok');
+    }
+  });
+
+  it("returns 'enrollment_required' when the auth error is MFA_ENROLLMENT_REQUIRED", () => {
+    const enrollError = createMfaError(MFA_ERROR_CODES.MFA_ENROLLMENT_REQUIRED, 'Enroll first');
+    const result = errorResult(enrollError);
+    const outcome = enforce(result);
+
+    expect(outcome.status).toBe('enrollment_required');
+  });
+
+  it("returns 'required' for a non-MFA auth error, wrapping the original message", () => {
+    const authErr: AuthError = {
+      code: 'UNAUTHORIZED',
+      message: 'Token expired',
+      statusCode: 401,
+    };
+    const result = errorResult(authErr);
+    const outcome = enforce(result);
+
+    expect(outcome.status).toBe('required');
+    if (outcome.status === 'required') {
+      expect(outcome.error.message).toBe('Token expired');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMfaErrorResponse
+// ---------------------------------------------------------------------------
+
+describe('parseMfaErrorResponse', () => {
+  it("returns 'required' for an mfa_required response with an mfa_token", () => {
+    const body = {
+      error: 'mfa_required',
+      mfa_token: 'mfa-token-xyz',
+      error_description: 'MFA is required',
+    };
+    const result = parseMfaErrorResponse(body);
+
+    expect(result.status).toBe('required');
+    if (result.status === 'required') {
+      expect(result.error.code).toBe(MFA_ERROR_CODES.MFA_REQUIRED);
+      expect(result.error.mfaToken).toBe('mfa-token-xyz');
+      expect(result.error.message).toBe('MFA is required');
+    }
+  });
+
+  it("returns 'required' for an mfa_required response without an mfa_token", () => {
+    const body = { error: 'mfa_required', error_description: 'Please complete MFA' };
+    const result = parseMfaErrorResponse(body);
+
+    expect(result.status).toBe('required');
+    if (result.status === 'required') {
+      expect(result.error.code).toBe(MFA_ERROR_CODES.MFA_REQUIRED);
+      expect('mfaToken' in result.error).toBe(false);
+    }
+  });
+
+  it("returns 'enrollment_required' for an mfa_enrollment_required response", () => {
+    const body = {
+      error: 'mfa_enrollment_required',
+      enrollment_url: 'https://tenant.auth0.com/enroll',
+    };
+    const result = parseMfaErrorResponse(body);
+
+    expect(result.status).toBe('enrollment_required');
+    if (result.status === 'enrollment_required') {
+      expect(result.enrollmentUrl).toBe('https://tenant.auth0.com/enroll');
+    }
+  });
+
+  it("returns 'enrollment_required' with empty enrollmentUrl when none is provided", () => {
+    const body = { error: 'mfa_enrollment_required' };
+    const result = parseMfaErrorResponse(body);
+
+    expect(result.status).toBe('enrollment_required');
+    if (result.status === 'enrollment_required') {
+      expect(result.enrollmentUrl).toBe('');
+    }
+  });
+
+  it("returns 'required' for mfa_token_invalid", () => {
+    const body = { error: 'mfa_token_invalid', error_description: 'Token is expired' };
+    const result = parseMfaErrorResponse(body);
+
+    expect(result.status).toBe('required');
+    if (result.status === 'required') {
+      expect(result.error.code).toBe(MFA_ERROR_CODES.MFA_TOKEN_INVALID);
+    }
+  });
+
+  it("returns 'required' for mfa_factor_not_enrolled", () => {
+    const body = { error: 'mfa_factor_not_enrolled', error_description: 'Factor missing' };
+    const result = parseMfaErrorResponse(body);
+
+    expect(result.status).toBe('required');
+    if (result.status === 'required') {
+      expect(result.error.code).toBe(MFA_ERROR_CODES.MFA_FACTOR_NOT_ENROLLED);
+    }
+  });
+
+  it("returns 'required' for a non-MFA error body", () => {
+    const body = { error: 'invalid_client', error_description: 'Unknown client' };
+    const result = parseMfaErrorResponse(body);
+
+    expect(result.status).toBe('required');
+    if (result.status === 'required') {
+      expect(result.error.code).toBe(MFA_ERROR_CODES.MFA_REQUIRED);
+      expect(result.error.message).toBe('Unknown client');
+    }
+  });
+
+  it("returns 'required' for a null body", () => {
+    const result = parseMfaErrorResponse(null);
+
+    expect(result.status).toBe('required');
+  });
+
+  it("returns 'required' for a non-object body", () => {
+    const result = parseMfaErrorResponse('error string');
+
+    expect(result.status).toBe('required');
+  });
+
+  it("returns 'required' for an object without an error field", () => {
+    const result = parseMfaErrorResponse({ message: 'something went wrong' });
+
+    expect(result.status).toBe('required');
+  });
+});

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -10,3 +10,4 @@ export type {
 } from './middleware.js';
 export { SessionManager, createAuth0TokenExchanger } from './session.js';
 export type { TokenExchanger } from './session.js';
+export { createMfaEnforcementMiddleware, parseMfaErrorResponse } from './mfa.js';

--- a/packages/core/src/auth/jwt.ts
+++ b/packages/core/src/auth/jwt.ts
@@ -56,25 +56,21 @@ export async function verifyAccessToken(
     ? (rawPermissions as string[])
     : undefined;
 
-  const result: TokenPayload =
-    permissions !== undefined
-      ? {
-          sub,
-          email: typeof email === 'string' ? email : '',
-          iss,
-          aud,
-          exp,
-          iat,
-          permissions,
-        }
-      : {
-          sub,
-          email: typeof email === 'string' ? email : '',
-          iss,
-          aud,
-          exp,
-          iat,
-        };
+  const rawAmr = payload['amr'];
+  const amr: readonly string[] | undefined = Array.isArray(rawAmr)
+    ? (rawAmr as string[])
+    : undefined;
+
+  const result: TokenPayload = {
+    sub,
+    email: typeof email === 'string' ? email : '',
+    iss,
+    aud,
+    exp,
+    iat,
+    ...(permissions !== undefined ? { permissions } : {}),
+    ...(amr !== undefined ? { amr } : {}),
+  };
 
   return result;
 }

--- a/packages/core/src/auth/mfa.ts
+++ b/packages/core/src/auth/mfa.ts
@@ -1,0 +1,104 @@
+import { MFA_ERROR_CODES, isMfaError, createMfaError } from '@sentinel/shared';
+import type { MfaChallengeResult } from '@sentinel/shared';
+import type { AuthMiddlewareResult } from './middleware.js';
+
+/**
+ * Returns a function that inspects an AuthMiddlewareResult for MFA completion status.
+ *
+ * The function accepts the auth result alongside the `amr` (Authentication Methods Reference)
+ * claim extracted from the verified token payload. When MFA is enforced, every authenticated
+ * request must present a token whose `amr` claim includes 'mfa'. Tokens without that claim
+ * were issued before an MFA challenge was completed.
+ *
+ * Callers that use `verifyAccessToken` to produce a `TokenPayload` can pass `payload.amr`
+ * directly. Callers that only hold an `AuthMiddlewareResult` can pass `undefined` for `amr`,
+ * which will always result in a 'required' outcome for authenticated tokens.
+ */
+export function createMfaEnforcementMiddleware(): (
+  result: AuthMiddlewareResult,
+  amr?: readonly string[],
+) => MfaChallengeResult {
+  return (result: AuthMiddlewareResult, amr?: readonly string[]): MfaChallengeResult => {
+    if (result.outcome === 'error') {
+      if (isMfaError(result.error)) {
+        if (result.error.code === MFA_ERROR_CODES.MFA_ENROLLMENT_REQUIRED) {
+          // When enrollment is required, callers need to redirect the user to set up a factor.
+          // The enrollment URL is not available at this layer — callers must supply it from
+          // the Auth0 error response or tenant configuration.
+          return {
+            status: 'enrollment_required',
+            enrollmentUrl: '',
+          };
+        }
+        return {
+          status: 'required',
+          error: result.error,
+        };
+      }
+
+      // Non-MFA auth failure: surface as a generic MFA required error so callers have a
+      // uniform type to handle, while preserving the original error message.
+      return {
+        status: 'required',
+        error: createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, result.error.message),
+      };
+    }
+
+    // Authenticated — verify that the token declared MFA was used via the amr claim.
+    if (!amr?.includes('mfa')) {
+      return {
+        status: 'required',
+        error: createMfaError(
+          MFA_ERROR_CODES.MFA_REQUIRED,
+          'Multi-factor authentication is required',
+        ),
+      };
+    }
+
+    return { status: 'completed' };
+  };
+}
+
+/**
+ * Parses an Auth0 error response body from a token exchange and returns a typed MfaChallengeResult.
+ *
+ * Auth0 returns `{ error: "mfa_required", mfa_token: "..." }` when MFA must be completed
+ * before a token can be issued. This function translates those responses so callers can
+ * act on the MFA challenge without inspecting raw response bodies.
+ */
+export function parseMfaErrorResponse(responseBody: unknown): MfaChallengeResult {
+  if (typeof responseBody !== 'object' || responseBody === null || !('error' in responseBody)) {
+    return {
+      status: 'required',
+      error: createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, 'Unknown MFA error'),
+    };
+  }
+
+  const body = responseBody as Record<string, unknown>;
+  const errorCode = body['error'];
+  const mfaToken = typeof body['mfa_token'] === 'string' ? body['mfa_token'] : undefined;
+  const errorDescription =
+    typeof body['error_description'] === 'string' ? body['error_description'] : 'MFA required';
+
+  if (errorCode === MFA_ERROR_CODES.MFA_ENROLLMENT_REQUIRED) {
+    const enrollmentUrl = typeof body['enrollment_url'] === 'string' ? body['enrollment_url'] : '';
+    return { status: 'enrollment_required', enrollmentUrl };
+  }
+
+  if (
+    errorCode === MFA_ERROR_CODES.MFA_REQUIRED ||
+    errorCode === MFA_ERROR_CODES.MFA_TOKEN_INVALID ||
+    errorCode === MFA_ERROR_CODES.MFA_FACTOR_NOT_ENROLLED
+  ) {
+    return {
+      status: 'required',
+      error: createMfaError(errorCode, errorDescription, mfaToken),
+    };
+  }
+
+  // Response contains an error field but it is not an MFA-specific code.
+  return {
+    status: 'required',
+    error: createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, errorDescription),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,8 @@ export {
   requirePermissions,
   SessionManager,
   createAuth0TokenExchanger,
+  createMfaEnforcementMiddleware,
+  parseMfaErrorResponse,
 } from './auth/index.js';
 export type {
   JwksGetter,

--- a/packages/shared/src/__tests__/mfa.test.ts
+++ b/packages/shared/src/__tests__/mfa.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { MFA_ERROR_CODES, isMfaError, createMfaError } from '../auth/mfa.js';
+import type { AuthError } from '../auth/types.js';
+
+describe('MFA_ERROR_CODES', () => {
+  it('contains the expected mfa_required code', () => {
+    expect(MFA_ERROR_CODES.MFA_REQUIRED).toBe('mfa_required');
+  });
+
+  it('contains the expected mfa_enrollment_required code', () => {
+    expect(MFA_ERROR_CODES.MFA_ENROLLMENT_REQUIRED).toBe('mfa_enrollment_required');
+  });
+
+  it('contains the expected mfa_token_invalid code', () => {
+    expect(MFA_ERROR_CODES.MFA_TOKEN_INVALID).toBe('mfa_token_invalid');
+  });
+
+  it('contains the expected mfa_factor_not_enrolled code', () => {
+    expect(MFA_ERROR_CODES.MFA_FACTOR_NOT_ENROLLED).toBe('mfa_factor_not_enrolled');
+  });
+});
+
+describe('isMfaError', () => {
+  it('returns true for an error with an MFA error code', () => {
+    const error: AuthError = {
+      code: MFA_ERROR_CODES.MFA_REQUIRED,
+      message: 'MFA is required',
+      statusCode: 403,
+    };
+
+    expect(isMfaError(error)).toBe(true);
+  });
+
+  it('returns true for mfa_enrollment_required code', () => {
+    const error: AuthError = {
+      code: MFA_ERROR_CODES.MFA_ENROLLMENT_REQUIRED,
+      message: 'Enrollment required',
+      statusCode: 403,
+    };
+
+    expect(isMfaError(error)).toBe(true);
+  });
+
+  it('returns true for mfa_token_invalid code', () => {
+    const error: AuthError = {
+      code: MFA_ERROR_CODES.MFA_TOKEN_INVALID,
+      message: 'MFA token is invalid',
+      statusCode: 403,
+    };
+
+    expect(isMfaError(error)).toBe(true);
+  });
+
+  it('returns true for mfa_factor_not_enrolled code', () => {
+    const error: AuthError = {
+      code: MFA_ERROR_CODES.MFA_FACTOR_NOT_ENROLLED,
+      message: 'Factor not enrolled',
+      statusCode: 403,
+    };
+
+    expect(isMfaError(error)).toBe(true);
+  });
+
+  it('returns false for a non-MFA error code', () => {
+    const error: AuthError = {
+      code: 'UNAUTHORIZED',
+      message: 'Not authenticated',
+      statusCode: 401,
+    };
+
+    expect(isMfaError(error)).toBe(false);
+  });
+
+  it('returns false for FORBIDDEN error code', () => {
+    const error: AuthError = {
+      code: 'FORBIDDEN',
+      message: 'Access denied',
+      statusCode: 403,
+    };
+
+    expect(isMfaError(error)).toBe(false);
+  });
+
+  it('returns false for AUTH_CONFIG_ERROR code', () => {
+    const error: AuthError = {
+      code: 'AUTH_CONFIG_ERROR',
+      message: 'Config error',
+      statusCode: 500,
+    };
+
+    expect(isMfaError(error)).toBe(false);
+  });
+});
+
+describe('createMfaError', () => {
+  it('creates an MfaError with the correct code, message, and statusCode', () => {
+    const err = createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, 'MFA is required');
+
+    expect(err.code).toBe(MFA_ERROR_CODES.MFA_REQUIRED);
+    expect(err.message).toBe('MFA is required');
+    expect(err.statusCode).toBe(403);
+  });
+
+  it('does not include mfaToken when not provided', () => {
+    const err = createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, 'MFA is required');
+
+    expect('mfaToken' in err).toBe(false);
+  });
+
+  it('includes mfaToken when provided', () => {
+    const err = createMfaError(MFA_ERROR_CODES.MFA_REQUIRED, 'MFA is required', 'mfa-token-abc');
+
+    expect(err.mfaToken).toBe('mfa-token-abc');
+  });
+
+  it('creates an enrollment_required error with the correct code', () => {
+    const err = createMfaError(MFA_ERROR_CODES.MFA_ENROLLMENT_REQUIRED, 'Please enroll in MFA');
+
+    expect(err.code).toBe(MFA_ERROR_CODES.MFA_ENROLLMENT_REQUIRED);
+    expect(err.statusCode).toBe(403);
+  });
+
+  it('creates a factor_not_enrolled error with mfaToken', () => {
+    const err = createMfaError(
+      MFA_ERROR_CODES.MFA_FACTOR_NOT_ENROLLED,
+      'Factor not enrolled',
+      'tok-xyz',
+    );
+
+    expect(err.code).toBe(MFA_ERROR_CODES.MFA_FACTOR_NOT_ENROLLED);
+    expect(err.mfaToken).toBe('tok-xyz');
+  });
+
+  it('isMfaError returns true for errors produced by createMfaError', () => {
+    const err = createMfaError(MFA_ERROR_CODES.MFA_TOKEN_INVALID, 'Invalid token');
+
+    expect(isMfaError(err)).toBe(true);
+  });
+});

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -8,3 +8,5 @@ export type {
   WorkerTokenRequest,
   WorkerToken,
 } from './session.js';
+export { MFA_ERROR_CODES, isMfaError, createMfaError } from './mfa.js';
+export type { MfaErrorCode, MfaError, MfaChallengeResult } from './mfa.js';

--- a/packages/shared/src/auth/mfa.ts
+++ b/packages/shared/src/auth/mfa.ts
@@ -1,0 +1,50 @@
+import type { AuthError } from './types.js';
+
+/**
+ * Auth0 error codes returned when MFA is required or not properly completed.
+ * These correspond to error values in Auth0's OAuth token exchange responses.
+ */
+export const MFA_ERROR_CODES = {
+  MFA_REQUIRED: 'mfa_required',
+  MFA_ENROLLMENT_REQUIRED: 'mfa_enrollment_required',
+  MFA_TOKEN_INVALID: 'mfa_token_invalid',
+  MFA_FACTOR_NOT_ENROLLED: 'mfa_factor_not_enrolled',
+} as const;
+
+export type MfaErrorCode = (typeof MFA_ERROR_CODES)[keyof typeof MFA_ERROR_CODES];
+
+/**
+ * An AuthError specialization for MFA-related failures.
+ * The optional mfaToken is the short-lived token Auth0 returns in a mfa_required response
+ * to allow the client to continue the MFA challenge flow.
+ */
+export interface MfaError extends AuthError {
+  readonly code: MfaErrorCode;
+  readonly mfaToken?: string;
+}
+
+/**
+ * The outcome of inspecting a token or Auth0 response for MFA status.
+ * - completed: the token contains a valid mfa amr claim
+ * - required: MFA must be completed before the request can proceed
+ * - enrollment_required: the user has not yet enrolled an MFA factor
+ */
+export type MfaChallengeResult =
+  | { readonly status: 'completed' }
+  | { readonly status: 'required'; readonly error: MfaError }
+  | { readonly status: 'enrollment_required'; readonly enrollmentUrl: string };
+
+/** Returns true when the given AuthError is an MFA-specific error. */
+export function isMfaError(error: AuthError): error is MfaError {
+  return Object.values(MFA_ERROR_CODES).includes(error.code as MfaErrorCode);
+}
+
+/** Creates a typed MfaError for the given MFA error code and message. */
+export function createMfaError(code: MfaErrorCode, message: string, mfaToken?: string): MfaError {
+  return {
+    code,
+    message,
+    statusCode: 403,
+    ...(mfaToken !== undefined ? { mfaToken } : {}),
+  };
+}

--- a/packages/shared/src/auth/types.ts
+++ b/packages/shared/src/auth/types.ts
@@ -28,6 +28,8 @@ export interface TokenPayload {
   readonly exp: number;
   readonly iat: number;
   readonly permissions?: readonly string[];
+  /** Authentication Methods Reference — indicates the methods used to authenticate the user. */
+  readonly amr?: readonly string[];
 }
 
 export type AuthResult =

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,11 +12,15 @@ export type SentinelVersion = typeof SENTINEL_VERSION;
 export type CheckResult = { status: 'pass' } | { status: 'fail'; reason: string };
 
 export type { AuthConfig, AuthUser, TokenPayload, AuthResult, AuthError } from './auth/index.js';
+export type { MfaErrorCode, MfaError, MfaChallengeResult } from './auth/index.js';
 export {
   loadAuthConfig,
   unauthorizedError,
   forbiddenError,
   authConfigError,
+  MFA_ERROR_CODES,
+  isMfaError,
+  createMfaError,
 } from './auth/index.js';
 export type {
   SessionConfig,


### PR DESCRIPTION
## Summary
- Add MFA error types, codes, and type guards to `@sentinel/shared`
- Add `amr` claim to `TokenPayload` for MFA completion detection
- Add `createMfaEnforcementMiddleware` and `parseMfaErrorResponse` to `@sentinel/core`
- Add Auth0 MFA setup documentation (`docs/auth0-mfa-setup.md`)
- 37 new tests covering MFA types, middleware, and error parsing

## Test plan
- [x] `pnpm test` — all tests pass
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)