### PR TITLE
feat(auth): add role-based access control with Auth0 RBAC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,18 +15,20 @@ sentinel/
 ├── packages/
 │   ├── shared/           # @sentinel/shared — shared types and utilities (no internal deps)
 │   │   └── src/
-│   │       ├── index.ts          # Public API: version constants, CheckResult, auth types/config/errors/session
+│   │       ├── index.ts          # Public API: version constants, CheckResult, auth types/config/errors/session/mfa/rbac
 │   │       ├── auth/
 │   │       │   ├── types.ts      # AuthConfig, AuthUser, TokenPayload (incl. amr), AuthResult, AuthError
 │   │       │   ├── config.ts     # loadAuthConfig() — reads Auth0 env vars, throws on missing
 │   │       │   ├── errors.ts     # unauthorizedError, forbiddenError, authConfigError factories
 │   │       │   ├── session.ts    # SessionConfig, TokenSet, TokenRefreshResult, WorkerTokenRequest, WorkerToken
 │   │       │   ├── mfa.ts        # MFA_ERROR_CODES, MfaErrorCode, MfaError, MfaChallengeResult, isMfaError, createMfaError
+│   │       │   ├── rbac.ts       # ROLES, PERMISSIONS, ROLE_PERMISSIONS constants; hasPermission/hasRole helpers
 │   │       │   └── index.ts      # Barrel re-export for auth/
 │   │       └── __tests__/
 │   │           ├── index.test.ts # Unit tests for shared exports
 │   │           ├── auth.test.ts  # Unit tests for auth config loading and error factories
-│   │           └── mfa.test.ts   # Unit tests for MFA error types and helpers
+│   │           ├── mfa.test.ts   # Unit tests for MFA error types and helpers
+│   │           └── rbac.test.ts  # Unit tests for RBAC constants and helper functions
 │   ├── core/             # @sentinel/core — domain models and core business logic
 │   │   └── src/
 │   │       ├── index.ts          # Public API: Scenario interface, auth modules, re-exports from shared
@@ -34,6 +36,7 @@ sentinel/
 │   │       │   ├── jwt.ts        # verifyAccessToken() (extracts amr claim), createAuth0JwksGetter(), JwksGetter type
 │   │       │   ├── middleware.ts  # createAuthMiddleware(), requirePermissions() — framework-agnostic
 │   │       │   ├── mfa.ts        # createMfaEnforcementMiddleware(), parseMfaErrorResponse()
+│   │       │   ├── rbac.ts       # requireRole(), requirePermission(), createRbacMiddleware()
 │   │       │   ├── user.ts       # tokenPayloadToUser() — maps TokenPayload to AuthUser
 │   │       │   ├── session.ts    # SessionManager class, createAuth0TokenExchanger(), TokenExchanger type
 │   │       │   └── index.ts      # Barrel re-export for auth/
@@ -41,7 +44,8 @@ sentinel/
 │   │           ├── index.test.ts  # Unit tests for core exports
 │   │           ├── auth.test.ts   # Unit tests for JWT verification and auth middleware
 │   │           ├── session.test.ts # Unit tests for SessionManager (createTokenSet, refresh, needsRefresh, etc.)
-│   │           └── mfa.test.ts   # Unit tests for MFA enforcement middleware and response parsing
+│   │           ├── mfa.test.ts   # Unit tests for MFA enforcement middleware and response parsing
+│   │           └── rbac.test.ts  # Unit tests for RBAC middleware functions
 │   ├── cli/              # @sentinel/cli — command-line interface entry point
 │   │   └── src/
 │   │       ├── index.ts          # Public API: CLI_NAME, re-exports from core/shared
@@ -53,7 +57,8 @@ sentinel/
 │           └── __tests__/
 │               └── index.test.ts # Unit tests for web exports
 ├── docs/
-│   └── auth0-mfa-setup.md  # Auth0 MFA configuration guide and Sentinel error-handling reference
+│   ├── auth0-mfa-setup.md  # Auth0 MFA configuration guide and Sentinel error-handling reference
+│   └── auth0-rbac-setup.md  # Auth0 RBAC configuration guide: roles, permissions, token settings
 ├── Dockerfile            # Multi-stage build: base → deps → build → api → web
 ├── docker-compose.yml    # Full local stack: api, web, browser-worker, redis, postgres
 ├── .dockerignore         # Excludes node_modules, dist, .git, .env, .claude, coverage

--- a/docs/auth0-rbac-setup.md
+++ b/docs/auth0-rbac-setup.md
@@ -1,0 +1,134 @@
+# Auth0 RBAC Setup for Sentinel
+
+This document explains how to configure Auth0 Role-Based Access Control (RBAC) for the Sentinel
+platform so that roles and permissions are included in access tokens and enforced by the API.
+
+## Overview
+
+Sentinel uses three roles and six permissions. Roles group permissions so that users receive the
+correct access level without requiring per-user permission assignment.
+
+| Role     | Permissions granted                   |
+| -------- | ------------------------------------- |
+| admin    | All permissions                       |
+| engineer | tests:create, tests:run, results:read |
+| viewer   | results:read                          |
+
+Permissions:
+
+| Permission         | Description                           |
+| ------------------ | ------------------------------------- |
+| tests:create       | Create new test scenarios             |
+| tests:run          | Execute test runs                     |
+| tests:delete       | Delete test scenarios                 |
+| results:read       | View test results and reports         |
+| settings:manage    | Manage platform settings              |
+| credentials:manage | Manage stored credentials and secrets |
+
+---
+
+## Step 1: Define permissions in the Auth0 API settings
+
+Permissions must be defined on the API that represents your Sentinel backend before they can be
+assigned to roles.
+
+1. Log in to the [Auth0 Dashboard](https://manage.auth0.com/).
+2. Navigate to **Applications > APIs**.
+3. Open the API you created for Sentinel (identified by the `AUTH0_AUDIENCE` value).
+4. Select the **Permissions** tab.
+5. Add each of the following permissions with a meaningful description:
+
+   | Permission         | Description                           |
+   | ------------------ | ------------------------------------- |
+   | tests:create       | Create new test scenarios             |
+   | tests:run          | Execute test runs                     |
+   | tests:delete       | Delete test scenarios                 |
+   | results:read       | View test results and reports         |
+   | settings:manage    | Manage platform settings              |
+   | credentials:manage | Manage stored credentials and secrets |
+
+6. Click **Save** after adding all permissions.
+
+---
+
+## Step 2: Enable RBAC and add permissions to access tokens
+
+By default, Auth0 does not include permissions in access tokens. You must enable this setting on
+the API.
+
+1. In the Auth0 Dashboard, navigate to **Applications > APIs**.
+2. Open your Sentinel API.
+3. Select the **Settings** tab.
+4. Scroll to the **RBAC Settings** section.
+5. Enable the toggle **Enable RBAC**.
+6. Enable the toggle **Add Permissions in the Access Token**.
+7. Click **Save Changes**.
+
+With this setting active, the `permissions` claim will be included in every access token issued
+for this API, containing only the permissions the user has been granted through their assigned
+roles.
+
+---
+
+## Step 3: Create roles in the Auth0 Dashboard
+
+1. In the Auth0 Dashboard, navigate to **User Management > Roles**.
+2. Click **Create Role** and create the following three roles:
+   - **Name:** `admin`
+     **Description:** Full administrative access to the Sentinel platform.
+
+   - **Name:** `engineer`
+     **Description:** Can create and run tests and view results.
+
+   - **Name:** `viewer`
+     **Description:** Read-only access to test results.
+
+3. After creating each role, open it and select the **Permissions** tab.
+4. Click **Add Permissions**, select your Sentinel API from the dropdown, and add the permissions
+   that correspond to the table in the Overview section above.
+5. Click **Add Permissions** to confirm.
+
+---
+
+## Step 4: Assign roles to users
+
+1. In the Auth0 Dashboard, navigate to **User Management > Users**.
+2. Search for or select the user you want to assign a role to.
+3. Select the **Roles** tab.
+4. Click **Assign Roles**.
+5. Select the appropriate role (`admin`, `engineer`, or `viewer`) and click **Assign**.
+
+The user's next access token will include the permissions associated with their assigned role in
+the `permissions` claim.
+
+---
+
+## Verifying the setup
+
+After completing the steps above, you can verify the configuration by inspecting an access token:
+
+1. Obtain an access token for a user with an assigned role using your preferred Auth0 flow.
+2. Decode the token at [jwt.io](https://jwt.io/).
+3. Confirm the payload contains a `permissions` array with the expected values. For example, a
+   user with the `engineer` role should see:
+
+   ```json
+   {
+     "permissions": ["tests:create", "tests:run", "results:read"]
+   }
+   ```
+
+If the `permissions` array is absent, verify that the **Add Permissions in the Access Token**
+setting is enabled on the API (Step 2).
+
+---
+
+## Local development
+
+For local development you can skip real Auth0 integration by using a local JWKS fixture in tests.
+The `createRbacMiddleware`, `requireRole`, and `requirePermission` functions in `@sentinel/core`
+work against the same `AuthUser` type regardless of how the token was issued, so any test that
+injects a properly shaped user object will exercise the RBAC logic without network calls.
+
+See `packages/core/src/__tests__/rbac.test.ts` for examples of how to sign test JWTs with a
+local key pair using the `jose` library.

--- a/packages/core/src/__tests__/rbac.test.ts
+++ b/packages/core/src/__tests__/rbac.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { SignJWT, generateKeyPair, exportJWK, createLocalJWKSet } from 'jose';
+import type { CryptoKey, JWK } from 'jose';
+import { ROLES, PERMISSIONS } from '@sentinel/shared';
+import type { AuthConfig, AuthUser } from '@sentinel/shared';
+import { requireRole, requirePermission, createRbacMiddleware } from '../auth/rbac.js';
+import type { JwksGetter } from '../auth/jwt.js';
+import type { AuthRequest } from '../auth/middleware.js';
+
+// ---------------------------------------------------------------------------
+// Shared test fixture — one key pair used across all JWT tests in this file
+// ---------------------------------------------------------------------------
+
+let privateKey: CryptoKey;
+let mockJwks: JwksGetter;
+
+const TEST_CONFIG: AuthConfig = {
+  domain: 'test.auth0.com',
+  clientId: 'client-123',
+  clientSecret: 'secret-abc',
+  audience: 'https://api.test.com',
+  callbackUrl: 'https://app.test.com/callback',
+  logoutUrl: 'https://app.test.com/logout',
+};
+
+const ISSUER = `https://${TEST_CONFIG.domain}/`;
+
+beforeAll(async () => {
+  const { privateKey: priv, publicKey: pub } = await generateKeyPair('RS256');
+  privateKey = priv;
+
+  const publicJwk: JWK = { ...(await exportJWK(pub)), use: 'sig', alg: 'RS256', kid: 'test-key-1' };
+  mockJwks = createLocalJWKSet({ keys: [publicJwk] });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    sub: 'user|test',
+    email: 'test@example.com',
+    name: 'Test User',
+    roles: [],
+    permissions: [],
+    ...overrides,
+  };
+}
+
+interface TokenOptions {
+  sub?: string;
+  email?: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  permissions?: string[];
+}
+
+async function signTestToken(opts: TokenOptions = {}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const builder = new SignJWT({
+    sub: opts.sub ?? 'user|123',
+    email: opts.email ?? 'user@example.com',
+    ...(opts.permissions !== undefined && { permissions: opts.permissions }),
+  })
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
+    .setIssuer(opts.iss ?? ISSUER)
+    .setAudience(opts.aud ?? TEST_CONFIG.audience)
+    .setIssuedAt(now);
+
+  if (opts.exp !== undefined) {
+    builder.setExpirationTime(opts.exp);
+  } else {
+    builder.setExpirationTime(now + 3600);
+  }
+
+  return builder.sign(privateKey);
+}
+
+function makeRequest(authorization?: string): AuthRequest {
+  return {
+    headers: authorization !== undefined ? { authorization } : {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// requireRole
+// ---------------------------------------------------------------------------
+
+describe('requireRole', () => {
+  it('returns authenticated when user has the required role', () => {
+    const user = makeUser({ roles: [ROLES.ENGINEER] });
+    const result = requireRole(ROLES.ENGINEER)(user);
+
+    expect(result.outcome).toBe('authenticated');
+    if (result.outcome === 'authenticated') {
+      expect(result.user).toBe(user);
+    }
+  });
+
+  it('returns authenticated when user has one of multiple accepted roles', () => {
+    const user = makeUser({ roles: [ROLES.ADMIN] });
+    const result = requireRole(ROLES.ENGINEER, ROLES.ADMIN)(user);
+
+    expect(result.outcome).toBe('authenticated');
+  });
+
+  it('returns 403 error when user has none of the required roles', () => {
+    const user = makeUser({ roles: [ROLES.VIEWER] });
+    const result = requireRole(ROLES.ADMIN, ROLES.ENGINEER)(user);
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(403);
+      expect(result.error.code).toBe('FORBIDDEN');
+    }
+  });
+
+  it('returns 403 error when user has no roles at all', () => {
+    const user = makeUser({ roles: [] });
+    const result = requireRole(ROLES.VIEWER)(user);
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(403);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requirePermission
+// ---------------------------------------------------------------------------
+
+describe('requirePermission', () => {
+  it('returns authenticated when user has the required typed permission', () => {
+    const user = makeUser({ permissions: [PERMISSIONS.RESULTS_READ] });
+    const result = requirePermission(PERMISSIONS.RESULTS_READ)(user);
+
+    expect(result.outcome).toBe('authenticated');
+  });
+
+  it('returns authenticated when user has all of multiple required permissions', () => {
+    const user = makeUser({
+      permissions: [PERMISSIONS.TESTS_CREATE, PERMISSIONS.TESTS_RUN, PERMISSIONS.RESULTS_READ],
+    });
+    const result = requirePermission(PERMISSIONS.TESTS_CREATE, PERMISSIONS.RESULTS_READ)(user);
+
+    expect(result.outcome).toBe('authenticated');
+  });
+
+  it('returns 403 error when user is missing a required permission', () => {
+    const user = makeUser({ permissions: [PERMISSIONS.RESULTS_READ] });
+    const result = requirePermission(PERMISSIONS.TESTS_CREATE)(user);
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(403);
+      expect(result.error.code).toBe('FORBIDDEN');
+      expect(result.error.message).toContain(PERMISSIONS.TESTS_CREATE);
+    }
+  });
+
+  it('returns 403 error when user has no permissions', () => {
+    const user = makeUser({ permissions: [] });
+    const result = requirePermission(PERMISSIONS.RESULTS_READ)(user);
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(403);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createRbacMiddleware
+// ---------------------------------------------------------------------------
+
+describe('createRbacMiddleware', () => {
+  it('returns authenticated when token is valid and user has the required permission', async () => {
+    const token = await signTestToken({
+      sub: 'user|456',
+      email: 'alice@example.com',
+      permissions: [PERMISSIONS.RESULTS_READ],
+    });
+    const middleware = createRbacMiddleware(TEST_CONFIG, mockJwks, [PERMISSIONS.RESULTS_READ]);
+    const result = await middleware(makeRequest(`Bearer ${token}`));
+
+    expect(result.outcome).toBe('authenticated');
+    if (result.outcome === 'authenticated') {
+      expect(result.user.sub).toBe('user|456');
+      expect(result.user.email).toBe('alice@example.com');
+    }
+  });
+
+  it('returns 401 when the Authorization header is missing', async () => {
+    const middleware = createRbacMiddleware(TEST_CONFIG, mockJwks, [PERMISSIONS.RESULTS_READ]);
+    const result = await middleware(makeRequest());
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(401);
+      expect(result.error.code).toBe('UNAUTHORIZED');
+    }
+  });
+
+  it('returns 401 when the token is invalid', async () => {
+    const middleware = createRbacMiddleware(TEST_CONFIG, mockJwks, [PERMISSIONS.RESULTS_READ]);
+    const result = await middleware(makeRequest('Bearer invalid.token.here'));
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(401);
+    }
+  });
+
+  it('returns 403 when token is valid but user lacks required permissions', async () => {
+    const token = await signTestToken({
+      permissions: [PERMISSIONS.RESULTS_READ],
+    });
+    const middleware = createRbacMiddleware(TEST_CONFIG, mockJwks, [PERMISSIONS.TESTS_DELETE]);
+    const result = await middleware(makeRequest(`Bearer ${token}`));
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(403);
+      expect(result.error.code).toBe('FORBIDDEN');
+      expect(result.error.message).toContain(PERMISSIONS.TESTS_DELETE);
+    }
+  });
+
+  it('returns 403 when token is valid but user has no permissions at all', async () => {
+    const token = await signTestToken({ permissions: [] });
+    const middleware = createRbacMiddleware(TEST_CONFIG, mockJwks, [PERMISSIONS.SETTINGS_MANAGE]);
+    const result = await middleware(makeRequest(`Bearer ${token}`));
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(403);
+    }
+  });
+
+  it('returns authenticated when multiple required permissions are all present', async () => {
+    const token = await signTestToken({
+      permissions: [PERMISSIONS.TESTS_CREATE, PERMISSIONS.TESTS_RUN, PERMISSIONS.RESULTS_READ],
+    });
+    const middleware = createRbacMiddleware(TEST_CONFIG, mockJwks, [
+      PERMISSIONS.TESTS_CREATE,
+      PERMISSIONS.RESULTS_READ,
+    ]);
+    const result = await middleware(makeRequest(`Bearer ${token}`));
+
+    expect(result.outcome).toBe('authenticated');
+  });
+
+  it('returns 401 for an expired token', async () => {
+    const exp = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signTestToken({ exp });
+    const middleware = createRbacMiddleware(TEST_CONFIG, mockJwks, [PERMISSIONS.RESULTS_READ]);
+    const result = await middleware(makeRequest(`Bearer ${token}`));
+
+    expect(result.outcome).toBe('error');
+    if (result.outcome === 'error') {
+      expect(result.error.statusCode).toBe(401);
+    }
+  });
+});

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -11,3 +11,4 @@ export type {
 export { SessionManager, createAuth0TokenExchanger } from './session.js';
 export type { TokenExchanger } from './session.js';
 export { createMfaEnforcementMiddleware, parseMfaErrorResponse } from './mfa.js';
+export { requireRole, requirePermission, createRbacMiddleware } from './rbac.js';

--- a/packages/core/src/auth/rbac.ts
+++ b/packages/core/src/auth/rbac.ts
@@ -1,0 +1,65 @@
+import { forbiddenError } from '@sentinel/shared';
+import type { AuthUser } from '@sentinel/shared';
+import type { Role, Permission } from '@sentinel/shared';
+import { createAuthMiddleware } from './middleware.js';
+import type {
+  AuthMiddlewareFn,
+  AuthMiddlewareResult,
+  AuthRequest,
+  PermissionMiddlewareFn,
+} from './middleware.js';
+import { requirePermissions } from './middleware.js';
+import type { JwksGetter } from './jwt.js';
+import type { AuthConfig } from '@sentinel/shared';
+
+/**
+ * Returns a permission-check function that verifies the user holds at least one
+ * of the specified roles. Returns 403 Forbidden if the user has none of them.
+ */
+export function requireRole(...roles: Role[]): PermissionMiddlewareFn {
+  return (user: AuthUser): AuthMiddlewareResult => {
+    const hasAny = roles.some((r) => user.roles.includes(r));
+
+    if (!hasAny) {
+      return {
+        outcome: 'error',
+        error: forbiddenError(`Insufficient role. Required one of: ${roles.join(', ')}`),
+      };
+    }
+
+    return { outcome: 'authenticated', user };
+  };
+}
+
+/**
+ * A typed wrapper around requirePermissions that restricts the argument type to
+ * the Permission union, providing compile-time safety for RBAC permission checks.
+ * Delegates entirely to the existing requirePermissions implementation.
+ */
+export function requirePermission(...permissions: Permission[]): PermissionMiddlewareFn {
+  return requirePermissions(...permissions);
+}
+
+/**
+ * Creates a combined middleware that first authenticates via JWT and then checks
+ * that the user holds all of the specified permissions. This is a convenience
+ * wrapper for endpoints that need both auth and permission enforcement in one step.
+ */
+export function createRbacMiddleware(
+  config: AuthConfig,
+  getJwks: JwksGetter,
+  requiredPermissions: readonly Permission[],
+): AuthMiddlewareFn {
+  const authMiddleware = createAuthMiddleware(config, getJwks);
+  const permissionCheck = requirePermissions(...requiredPermissions);
+
+  return async (request: AuthRequest): Promise<AuthMiddlewareResult> => {
+    const authResult = await authMiddleware(request);
+
+    if (authResult.outcome === 'error') {
+      return authResult;
+    }
+
+    return permissionCheck(authResult.user);
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,9 @@ export {
   createAuth0TokenExchanger,
   createMfaEnforcementMiddleware,
   parseMfaErrorResponse,
+  requireRole,
+  requirePermission,
+  createRbacMiddleware,
 } from './auth/index.js';
 export type {
   JwksGetter,

--- a/packages/shared/src/__tests__/rbac.test.ts
+++ b/packages/shared/src/__tests__/rbac.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ROLES,
+  PERMISSIONS,
+  ROLE_PERMISSIONS,
+  hasPermission,
+  hasAllPermissions,
+  hasAnyPermission,
+  hasRole,
+} from '../auth/rbac.js';
+import type { AuthUser } from '../auth/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    sub: 'user|test',
+    email: 'test@example.com',
+    name: 'Test User',
+    roles: [],
+    permissions: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ROLES constants
+// ---------------------------------------------------------------------------
+
+describe('ROLES', () => {
+  it('defines admin role', () => {
+    expect(ROLES.ADMIN).toBe('admin');
+  });
+
+  it('defines engineer role', () => {
+    expect(ROLES.ENGINEER).toBe('engineer');
+  });
+
+  it('defines viewer role', () => {
+    expect(ROLES.VIEWER).toBe('viewer');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PERMISSIONS constants
+// ---------------------------------------------------------------------------
+
+describe('PERMISSIONS', () => {
+  it('defines tests:create', () => {
+    expect(PERMISSIONS.TESTS_CREATE).toBe('tests:create');
+  });
+
+  it('defines tests:run', () => {
+    expect(PERMISSIONS.TESTS_RUN).toBe('tests:run');
+  });
+
+  it('defines tests:delete', () => {
+    expect(PERMISSIONS.TESTS_DELETE).toBe('tests:delete');
+  });
+
+  it('defines results:read', () => {
+    expect(PERMISSIONS.RESULTS_READ).toBe('results:read');
+  });
+
+  it('defines settings:manage', () => {
+    expect(PERMISSIONS.SETTINGS_MANAGE).toBe('settings:manage');
+  });
+
+  it('defines credentials:manage', () => {
+    expect(PERMISSIONS.CREDENTIALS_MANAGE).toBe('credentials:manage');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ROLE_PERMISSIONS mapping
+// ---------------------------------------------------------------------------
+
+describe('ROLE_PERMISSIONS', () => {
+  it('maps admin to all permissions', () => {
+    const allPermissions = Object.values(PERMISSIONS);
+    const adminPermissions = ROLE_PERMISSIONS[ROLES.ADMIN];
+
+    expect(adminPermissions).toHaveLength(allPermissions.length);
+    for (const permission of allPermissions) {
+      expect(adminPermissions).toContain(permission);
+    }
+  });
+
+  it('maps engineer to create, run, and read permissions', () => {
+    const engineerPermissions = ROLE_PERMISSIONS[ROLES.ENGINEER];
+
+    expect(engineerPermissions).toContain(PERMISSIONS.TESTS_CREATE);
+    expect(engineerPermissions).toContain(PERMISSIONS.TESTS_RUN);
+    expect(engineerPermissions).toContain(PERMISSIONS.RESULTS_READ);
+    expect(engineerPermissions).not.toContain(PERMISSIONS.TESTS_DELETE);
+    expect(engineerPermissions).not.toContain(PERMISSIONS.SETTINGS_MANAGE);
+    expect(engineerPermissions).not.toContain(PERMISSIONS.CREDENTIALS_MANAGE);
+  });
+
+  it('maps viewer to results:read only', () => {
+    const viewerPermissions = ROLE_PERMISSIONS[ROLES.VIEWER];
+
+    expect(viewerPermissions).toHaveLength(1);
+    expect(viewerPermissions).toContain(PERMISSIONS.RESULTS_READ);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasPermission
+// ---------------------------------------------------------------------------
+
+describe('hasPermission', () => {
+  it('returns true when user has the specified permission', () => {
+    const user = makeUser({ permissions: [PERMISSIONS.RESULTS_READ] });
+
+    expect(hasPermission(user, PERMISSIONS.RESULTS_READ)).toBe(true);
+  });
+
+  it('returns false when user lacks the specified permission', () => {
+    const user = makeUser({ permissions: [PERMISSIONS.RESULTS_READ] });
+
+    expect(hasPermission(user, PERMISSIONS.TESTS_CREATE)).toBe(false);
+  });
+
+  it('returns false for a user with no permissions', () => {
+    const user = makeUser({ permissions: [] });
+
+    expect(hasPermission(user, PERMISSIONS.RESULTS_READ)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAllPermissions
+// ---------------------------------------------------------------------------
+
+describe('hasAllPermissions', () => {
+  it('returns true when user has all required permissions', () => {
+    const user = makeUser({
+      permissions: [PERMISSIONS.TESTS_CREATE, PERMISSIONS.TESTS_RUN, PERMISSIONS.RESULTS_READ],
+    });
+
+    expect(hasAllPermissions(user, [PERMISSIONS.TESTS_CREATE, PERMISSIONS.RESULTS_READ])).toBe(
+      true,
+    );
+  });
+
+  it('returns false when user is missing at least one required permission', () => {
+    const user = makeUser({ permissions: [PERMISSIONS.RESULTS_READ] });
+
+    expect(hasAllPermissions(user, [PERMISSIONS.RESULTS_READ, PERMISSIONS.TESTS_CREATE])).toBe(
+      false,
+    );
+  });
+
+  it('returns true for an empty permissions list', () => {
+    const user = makeUser({ permissions: [] });
+
+    expect(hasAllPermissions(user, [])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAnyPermission
+// ---------------------------------------------------------------------------
+
+describe('hasAnyPermission', () => {
+  it('returns true when user has at least one of the required permissions', () => {
+    const user = makeUser({ permissions: [PERMISSIONS.RESULTS_READ] });
+
+    expect(hasAnyPermission(user, [PERMISSIONS.TESTS_CREATE, PERMISSIONS.RESULTS_READ])).toBe(true);
+  });
+
+  it('returns false when user has none of the required permissions', () => {
+    const user = makeUser({ permissions: [PERMISSIONS.RESULTS_READ] });
+
+    expect(hasAnyPermission(user, [PERMISSIONS.TESTS_CREATE, PERMISSIONS.TESTS_RUN])).toBe(false);
+  });
+
+  it('returns false for an empty permissions list', () => {
+    const user = makeUser({ permissions: [PERMISSIONS.RESULTS_READ] });
+
+    expect(hasAnyPermission(user, [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasRole
+// ---------------------------------------------------------------------------
+
+describe('hasRole', () => {
+  it('returns true when user has the specified role', () => {
+    const user = makeUser({ roles: [ROLES.ENGINEER] });
+
+    expect(hasRole(user, ROLES.ENGINEER)).toBe(true);
+  });
+
+  it('returns false when user does not have the specified role', () => {
+    const user = makeUser({ roles: [ROLES.VIEWER] });
+
+    expect(hasRole(user, ROLES.ADMIN)).toBe(false);
+  });
+
+  it('returns false for a user with no roles', () => {
+    const user = makeUser({ roles: [] });
+
+    expect(hasRole(user, ROLES.VIEWER)).toBe(false);
+  });
+});

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -10,3 +10,13 @@ export type {
 } from './session.js';
 export { MFA_ERROR_CODES, isMfaError, createMfaError } from './mfa.js';
 export type { MfaErrorCode, MfaError, MfaChallengeResult } from './mfa.js';
+export {
+  ROLES,
+  PERMISSIONS,
+  ROLE_PERMISSIONS,
+  hasPermission,
+  hasAllPermissions,
+  hasAnyPermission,
+  hasRole,
+} from './rbac.js';
+export type { Role, Permission } from './rbac.js';

--- a/packages/shared/src/auth/rbac.ts
+++ b/packages/shared/src/auth/rbac.ts
@@ -1,0 +1,46 @@
+import type { AuthUser } from './types.js';
+
+export const ROLES = {
+  ADMIN: 'admin',
+  ENGINEER: 'engineer',
+  VIEWER: 'viewer',
+} as const;
+
+export type Role = (typeof ROLES)[keyof typeof ROLES];
+
+export const PERMISSIONS = {
+  TESTS_CREATE: 'tests:create',
+  TESTS_RUN: 'tests:run',
+  TESTS_DELETE: 'tests:delete',
+  RESULTS_READ: 'results:read',
+  SETTINGS_MANAGE: 'settings:manage',
+  CREDENTIALS_MANAGE: 'credentials:manage',
+} as const;
+
+export type Permission = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];
+
+/**
+ * Maps each role to the permissions it grants.
+ * Admin receives all permissions; engineer and viewer receive progressively fewer.
+ */
+export const ROLE_PERMISSIONS: Record<Role, readonly Permission[]> = {
+  [ROLES.ADMIN]: Object.values(PERMISSIONS) as Permission[],
+  [ROLES.ENGINEER]: [PERMISSIONS.TESTS_CREATE, PERMISSIONS.TESTS_RUN, PERMISSIONS.RESULTS_READ],
+  [ROLES.VIEWER]: [PERMISSIONS.RESULTS_READ],
+} as const;
+
+export function hasPermission(user: AuthUser, permission: Permission): boolean {
+  return user.permissions.includes(permission);
+}
+
+export function hasAllPermissions(user: AuthUser, permissions: readonly Permission[]): boolean {
+  return permissions.every((p) => user.permissions.includes(p));
+}
+
+export function hasAnyPermission(user: AuthUser, permissions: readonly Permission[]): boolean {
+  return permissions.some((p) => user.permissions.includes(p));
+}
+
+export function hasRole(user: AuthUser, role: Role): boolean {
+  return user.roles.includes(role);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,6 +21,13 @@ export {
   MFA_ERROR_CODES,
   isMfaError,
   createMfaError,
+  ROLES,
+  PERMISSIONS,
+  ROLE_PERMISSIONS,
+  hasPermission,
+  hasAllPermissions,
+  hasAnyPermission,
+  hasRole,
 } from './auth/index.js';
 export type {
   SessionConfig,
@@ -29,3 +36,4 @@ export type {
   WorkerTokenRequest,
   WorkerToken,
 } from './auth/index.js';
+export type { Role, Permission } from './auth/index.js';


### PR DESCRIPTION
## Summary
- Add RBAC types (`Role`, `Permission`, `ROLE_PERMISSIONS`) and helpers to `@sentinel/shared`
- Add `requireRole`, `requirePermission`, `createRbacMiddleware` to `@sentinel/core`
- Three roles: admin (all permissions), engineer (create/run/read), viewer (read-only)
- Six permissions: tests:create, tests:run, tests:delete, results:read, settings:manage, credentials:manage
- Add Auth0 RBAC setup documentation (`docs/auth0-rbac-setup.md`)
- 39 new tests covering RBAC constants, helpers, and middleware

## Test plan
- [x] `pnpm test` — all tests pass (89 total)
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)